### PR TITLE
Hotfix for failure with newest xarray version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # Bookend python versions
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/ci/requirements/py36-bare-minimum.yml
+++ b/ci/requirements/py36-bare-minimum.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy
   - pooch
   - rasterio
-  - xarray
+  - xarray<0.19.0
 # for testing
   - pytest
   - pytest-cov

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -65,6 +65,7 @@ Bug Fixes
   (:issue:`157`).
 - Move ``_flatten_polygons`` to ``utils`` and raise an error when something else than
   a ``Polygon`` or ``MultiPolygon`` is passed (:pull:`211`).
+- Fix errors with masking due to xarray >=0.19.0 (:pull:`234`). By `Julius Busecke <https://github.com/jbusecke>`_.
 
 Docs
 ~~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -65,7 +65,7 @@ Bug Fixes
   (:issue:`157`).
 - Move ``_flatten_polygons`` to ``utils`` and raise an error when something else than
   a ``Polygon`` or ``MultiPolygon`` is passed (:pull:`211`).
-- Fix errors with masking due to xarray >=0.19.0 (:pull:`234`). By `Julius Busecke <https://github.com/jbusecke>`_.
+- Fix incompatibility with xarray >=0.19.0 (:pull:`234`). By `Julius Busecke <https://github.com/jbusecke>`_.
 
 Docs
 ~~~~

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 import xarray as xr
+from xarray.core.dataarray import DataArray
 
 from .utils import (
     _equally_spaced_on_split_lon,
@@ -298,10 +299,16 @@ def _create_xarray_2D(mask, lon_or_obj, lat, lon_name, lat_name):
 
     # dict with the coordinates
     coords = {
-        dim1D_names[0]: dim1D_0,
-        dim1D_names[1]: dim1D_1,
-        lat_name: (dim1D_names, lat2D.data),
-        lon_name: (dim1D_names, lon2D.data),
+        dim1D_names[0]: dim1D_0.data,
+        dim1D_names[1]: dim1D_1.data,
+        lat_name: (
+            dim1D_names,
+            lat2D.data if isinstance(lat2D, xr.DataArray) else lat2D,
+        ),
+        lon_name: (
+            dim1D_names,
+            lon2D.data if isinstance(lon2D, xr.DataArray) else lon2D,
+        ),
     }
 
     mask = xr.DataArray(mask, coords=coords, dims=dim1D_names)

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 import xarray as xr
-from xarray.core.dataarray import DataArray
 
 from .utils import (
     _equally_spaced_on_split_lon,

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -300,8 +300,8 @@ def _create_xarray_2D(mask, lon_or_obj, lat, lon_name, lat_name):
     coords = {
         dim1D_names[0]: dim1D_0,
         dim1D_names[1]: dim1D_1,
-        lat_name: (dim1D_names, lat2D),
-        lon_name: (dim1D_names, lon2D),
+        lat_name: (dim1D_names, lat2D.data),
+        lon_name: (dim1D_names, lon2D.data),
     }
 
     mask = xr.DataArray(mask, coords=coords, dims=dim1D_names)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
         "Topic :: Scientific/Engineering :: GIS",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

I have noticed that the CI over at https://github.com/jbusecke/cmip6_preprocessing/issues/173 is broken. Some of these changes can be fixed there, but there are some failures that are caused by this package.

This is a rather naive fix for the issue.
