### PR TITLE
update regionmask install on RTD

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -27,13 +27,13 @@ dependencies:
 # dependencies to build the docu
   # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   - docutils==0.16
-  - jupyter
+  - ipykernel
   - nbconvert
   - numpydoc
   - pillow
   - pip
-  - sphinx_rtd_theme==0.4.3
-  - sphinx==2.1.2
+  - sphinx_rtd_theme
+  - sphinx
 # for regionmask intake example
   - pip:
     - intake_geopandas>=0.2.4

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -38,3 +38,5 @@ dependencies:
   - pip:
     - intake_geopandas>=0.2.4
     - msgpack
+    # install regionmask relative to this file. Needs to be editable to be accepted.
+    - -e ../..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ copyright = "2016-%s, regionmask Developers" % datetime.datetime.now().year
 # built documents.
 #
 # The short X.Y version.
-version = regionmask.__version__
+version = regionmask.__version__.split("+")[0]
 # The full version, including alpha/beta/rc tags.
 release = regionmask.__version__
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,6 +31,8 @@ Bug Fixes
 Docs
 ~~~~
 
+- Install `regionmask` via `ci/requirements/docs.yml` on RTD using pip (:pull:`248`).
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,7 +31,10 @@ Bug Fixes
 Docs
 ~~~~
 
-- Install `regionmask` via `ci/requirements/docs.yml` on RTD using pip (:pull:`248`).
+- Install `regionmask` via `ci/requirements/docs.yml` on RTD using pip and update the
+  packages: don't require jupyter (but ipykernel, which leads to a smaller environment),
+  use new versions of sphinx and sphinx_rtd_theme (:pull:`248`).
+
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,23 +1,17 @@
-# .readthedocs.yml
 # Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 
 # Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
+# build documentation in the docs directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
 build:
-    image: stable
+    image: latest
 
 conda:
     environment: ci/requirements/docs.yml
-python:
-    version: 3.7
-    install:
-      - method: setuptools
-        path: .
 
 formats: []


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

See pyproj/xarray#4350. This installs regionmask via the `ci/requirements/docs.yml` file on RTD using pip. This will hopefully fix the missing version numbers on RTD.
