### PR TITLE
mask with pygeos

### DIFF
--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -42,6 +42,8 @@ POLICY_OVERRIDE = {
     # TODO remove this special case and the matching note in installing.rst
     #      after March 2022.
     "setuptools": (40, 4),
+    # cannot install pygeos=0.7 alongside shapely
+    "pygeos": (0, 9),
 }
 has_errors = False
 

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - python=3.7
+  - python
 # regionmask dependencies
   # https://github.com/SciTools/cartopy/pull/1646
   - cartopy=0.17
@@ -14,6 +14,7 @@ dependencies:
   - matplotlib-base==3.2
   - numpy
   - pooch
+  - pygeos
   - rasterio
   - xarray
 # depencies for the examples

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - matplotlib-base
   - numpy
   - pooch
+  - pygeos
   - rasterio
   - setuptools
   - xarray

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy=1.17
   - pandas=1.0
   - pooch=1.0
+  - pygeos=0.7
   - rasterio=1.0
   - setuptools=40.4
   - shapely=1.6

--- a/ci/requirements/py36-min-all-deps.yml
+++ b/ci/requirements/py36-min-all-deps.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy=1.17
   - pandas=1.0
   - pooch=1.0
-  - pygeos=0.7
+  - pygeos=0.9
   - rasterio=1.0
   - setuptools=40.4
   - shapely=1.6

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,7 @@ Note, however, that the optional dependency cartopy can be very difficult to ins
 Testing
 -------
 
-To run the test suite after installing regionmask, install `py.test <https://pytest.org>`__
+To run the test suite after installing regionmask, install `pytest <https://pytest.org>`__
 and run ``pytest`` in the root directory of regionmask.
 
 To install the development version (master), do:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,6 +22,12 @@ For plotting
 - `cartopy <http://scitools.org.uk/cartopy/>`__ for plotting on geographical maps and
   for downloading natural earth data.
 
+For faster masking
+~~~~~~~~~~~~~~~~~~
+
+- `pygeos <https://pygeos.readthedocs.io/en/stable/>`__ enables faster mask creations for
+  irregular and 2D grids.
+
 Instructions
 ------------
 
@@ -31,10 +37,10 @@ on the conda-forge channel.
 
 .. code-block:: bash
 
-    conda install -c conda-forge regionmask cartopy
+    conda install -c conda-forge regionmask cartopy pygeos
 
 All required dependencies can be installed with pip. You can thus install regionmask
-regionmask directly:
+directly:
 
 .. code-block:: bash
 
@@ -45,7 +51,8 @@ Note, however, that the optional dependency cartopy can be very difficult to ins
 Testing
 -------
 
-To run the test suite after installing regionmask, install `py.test <https://pytest.org>`__ and run ``pytest`` in the root directory of regionmask.
+To run the test suite after installing regionmask, install `py.test <https://pytest.org>`__
+and run ``pytest`` in the root directory of regionmask.
 
 To install the development version (master), do:
 

--- a/docs/notebooks/method.ipynb
+++ b/docs/notebooks/method.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "import warnings\n",
     "\n",
-    "warnings.filterwarnings(\"ignore\")"
+    "#warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -27,14 +27,7 @@
    "source": [
     "# Edge behavior and interiors\n",
     "\n",
-    "This notebook illustrates the edge behavior and how Polygon interiors are treated.\n"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    ".. note:: From version 0.5 ``regionmask`` treats points on the region borders differently and also considers poygon interiors (holes), e.g. the Caspian Sea in ``natural_earth.land_110`` region."
+    "This notebook illustrates the edge behavior (when a grid point falls on the edge of a polygon) and how polygon interiors are treated.\n"
    ]
   },
   {
@@ -106,14 +99,18 @@
    "source": [
     "## Methods\n",
     "\n",
-    "Regionmask offers two methods to rasterize regions\n",
+    "Regionmask offers three \"methods\"* to rasterize regions\n",
     "\n",
     "1. `rasterize`: fastest but only for equally-spaced grid, uses `rasterio.features.rasterize` internally.\n",
     "2. `shapely`: for irregular grids, uses `shapely.vectorized.contains` internally.\n",
+    "3. `pygeos`: a faster alternative for irregular grids. This is method is preferred over (2) if the optional dependency pygeos is installed. Uses `pygeos.STRtree` internally.\n",
     "\n",
     "All methods use the `lon` and `lat` coordinates to determine if a grid cell is in a region. `lon` and `lat` are assumed to indicate the *center* of the grid cell. Methods (1) and (2) have the same edge behavior and consider 'holes' in the regions. `regionmask` automatically determines which `method` to use.\n",
     "\n",
-    "(2) subtracts a tiny offset from `lon` and `lat` to achieve a edge behaviour consistent with (1). Due to [mapbox/rasterio/#1844](https://github.com/mapbox/rasterio/issues/1844) this is unfortunately also necessary for (1)."
+    "(2) and (3) subtract a tiny offset from `lon` and `lat` to achieve a edge behaviour consistent with (1). Due to [mapbox/rasterio#1844](https://github.com/mapbox/rasterio/issues/1844) this is unfortunately also necessary for (1).\n",
+    "\n",
+    "\n",
+    "\\*Note that all \"methods\" yield the same results."
    ]
   },
   {
@@ -122,7 +119,7 @@
    "source": [
     "## Edge behavior\n",
     "\n",
-    "As of version 0.5 `regionmask` has a new edge behavior - points that fall of the outline of a region are now consistently treated. This was not the case in earlier versions (xref [matplotlib/matplotlib#9704](https://github.com/matplotlib/matplotlib/issues/9704)). It's easiest to see the edge behaviour in an\n",
+    "The edge behavior determines how points that fall on the outline of a region are treated. It's easiest to see the edge behaviour in an\n",
     "\n",
     "### Example\n",
     "\n",
@@ -169,7 +166,8 @@
    "outputs": [],
    "source": [
     "mask_rasterize = region.mask(ds_US, method=\"rasterize\")\n",
-    "mask_shapely = region.mask(ds_US, method=\"shapely\")"
+    "mask_shapely = region.mask(ds_US, method=\"shapely\")\n",
+    "mask_pygeos = region.mask(ds_US, method=\"pygeos\")"
    ]
   },
   {
@@ -192,12 +190,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, axes = plt.subplots(1, 2, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
+    "f, axes = plt.subplots(1, 3, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
     "\n",
     "opt = dict(add_colorbar=False, ec=\"0.5\", lw=0.5, transform=ccrs.PlateCarree())\n",
     "\n",
     "mask_rasterize.plot(ax=axes[0], cmap=cmap1, **opt)\n",
     "mask_shapely.plot(ax=axes[1], cmap=cmap2, **opt)\n",
+    "mask_pygeos.plot(ax=axes[2], cmap=cmap3, **opt)\n",
     "\n",
     "\n",
     "for ax in axes:\n",
@@ -210,14 +209,15 @@
     "    )\n",
     "\n",
     "axes[0].set_title(\"rasterize\")\n",
-    "axes[1].set_title(\"shapely\")"
+    "axes[1].set_title(\"shapely\")\n",
+    "axes[2].set_title(\"pygeos\");"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Points indicate the grid cell centers (`lon` and `lat`), lines the grid cell borders, colored grid cells are selected to be part of the region. The top and right grid cells now belong to the region while the left and bottom grid cells do not. This choice is arbitrary but mimicks what `rasterio.features.rasterize` does. This avoids spurious columns of unassigned grid points as the following example shows.\n",
+    "Points indicate the grid cell centers (`lon` and `lat`), lines the grid cell borders, colored grid cells are selected to be part of the region. The top and right grid cells now belong to the region while the left and bottom grid cells do not. This choice is arbitrary but follows what `rasterio.features.rasterize` does. This avoids spurious columns of unassigned grid points as the following example shows.\n",
     "\n",
     "### SREX regions\n",
     "\n",
@@ -280,7 +280,7 @@
     ")\n",
     "\n",
     "\n",
-    "ax.set_title(\"new (rasterize + shapely)\");"
+    "ax.set_title(\"edge points are assigned to the left polygon\", fontsize=9);"
    ]
   },
   {
@@ -333,7 +333,8 @@
    "source": [
     "mask_global = region_global.mask(lon, lat)\n",
     "\n",
-    "# we need to manually create the mask\n",
+    "# the points at -180°E & -90°N were assigned\n",
+    "# need to manually remove them\n",
     "mask_global_nontreat = mask_global.copy()\n",
     "mask_global_nontreat[-1, :] = np.NaN\n",
     "mask_global_nontreat[:, 0] = np.NaN"
@@ -391,7 +392,9 @@
     "\n",
     "Points at -180°E (0°E) are mapped to 180°E (360°E). Points at -90°N are slightly shifted northwards (by 1 * 10 ** -10). Then it is tested if the shifted points belong to any region\n",
     "\n",
-    "This means that (i) a point at -180°E is part of the region that is present at 180°E (and not the one at -180°E) and (ii) only the points at -90°N get assigned to the region above."
+    "This means that (i) a point at -180°E is part of the region that is present at 180°E and not the one at -180°E (this is consistent with assigning points to the polygon *left* from it) and (ii) only the points at -90°N get assigned to the region above.\n",
+    "\n",
+    "This is illustrated in the figure below:"
    ]
   },
   {
@@ -414,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = region_global_2.plot(line_kws=dict(color=\"#b15928\", zorder=3), add_label=False,)\n",
+    "ax = region_global_2.plot(line_kws=dict(color=\"#b15928\", zorder=3, lw=1), add_label=False,)\n",
     "\n",
     "ax.plot(LON, LAT, \"o\", color=\"0.3\", ms=2, transform=ccrs.PlateCarree(), zorder=5)\n",
     "\n",
@@ -432,7 +435,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. note:: This only applies if the border of the region falls exactly on the point. One way to avoid the problem is to calculate the `fractional overlap <https://github.com/regionmask/regionmask/issues/38>`_ of each gridpoint with the regions (which is not yet implemented)."
+    ".. note:: This only applies if the border of the region falls *exactly* on the point. One way to avoid the problem is to calculate the `fractional overlap <https://github.com/regionmask/regionmask/issues/38>`_ of each gridpoint with the regions (which is not yet implemented)."
    ]
   },
   {
@@ -441,7 +444,7 @@
    "source": [
     "## Polygon interiors\n",
     "\n",
-    "`Polygons` can have interior boundaries ('holes'). Prior to version 0.5.0 these were not considered and e.g. the Caspian Sea was not 'unmasked'.\n",
+    "`Polygons` can have interior boundaries ('holes'). regionmask unmasks these regions.\n",
     "\n",
     "### Example\n",
     "\n",
@@ -458,7 +461,7 @@
     "    [[-86.0, 44.0], [-86.0, 34.0], [-94.0, 34.0], [-94.0, 44.0], [-86.0, 44.0],]\n",
     ")\n",
     "\n",
-    "poly = Polygon(outline, [interior])\n",
+    "poly = Polygon(outline, holes=[interior])\n",
     "\n",
     "region_with_hole = regionmask.Regions([poly])"
    ]
@@ -470,7 +473,8 @@
    "outputs": [],
    "source": [
     "mask_hole_rasterize = region_with_hole.mask(ds_US, method=\"rasterize\")\n",
-    "mask_hole_shapely = region_with_hole.mask(ds_US, method=\"shapely\")"
+    "mask_hole_shapely = region_with_hole.mask(ds_US, method=\"shapely\")\n",
+    "mask_hole_pygeos = region_with_hole.mask(ds_US, method=\"pygeos\")"
    ]
   },
   {
@@ -479,32 +483,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, axes = plt.subplots(1, 2, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
+    "f, axes = plt.subplots(1, 3, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
     "\n",
     "opt = dict(add_colorbar=False, ec=\"0.5\", lw=0.5)\n",
     "\n",
     "mask_hole_rasterize.plot(ax=axes[0], cmap=cmap1, **opt)\n",
     "mask_hole_shapely.plot(ax=axes[1], cmap=cmap2, **opt)\n",
+    "mask_hole_pygeos.plot(ax=axes[2], cmap=cmap3, **opt)\n",
     "\n",
     "for ax in axes:\n",
-    "    region.plot_regions(ax=ax, add_label=False)\n",
+    "    region_with_hole.plot_regions(ax=ax, add_label=False, line_kws=dict(lw=1))\n",
     "\n",
     "    ax.set_extent([-105, -75, 25, 55], ccrs.PlateCarree())\n",
-    "    ax.coastlines(lw=0.5)\n",
+    "    ax.coastlines(lw=0.25)\n",
     "\n",
     "    ax.plot(\n",
     "        ds_US.LON, ds_US.lat, \"o\", color=\"0.5\", ms=0.5, transform=ccrs.PlateCarree()\n",
     "    )\n",
     "\n",
     "axes[0].set_title(\"rasterize\")\n",
-    "axes[1].set_title(\"shapely\");"
+    "axes[1].set_title(\"shapely\")\n",
+    "axes[2].set_title(\"pygeos\");"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  Caspian Sea"
+    "Note how the edge behavior of the interior is inverse to the edge behavior of the outerior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Caspian Sea\n",
+    "\n",
+    "The Caspian Sea is defined as polygon interior."
    ]
   },
   {
@@ -515,7 +530,7 @@
    "source": [
     "land110 = regionmask.defined_regions.natural_earth.land_110\n",
     "\n",
-    "land_new = land110.mask(ds_GLOB)"
+    "mask_land110 = land110.mask(ds_GLOB)"
    ]
   },
   {
@@ -526,9 +541,7 @@
    "source": [
     "f, ax = plt.subplots(1, 1, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
     "\n",
-    "opt = dict(add_colorbar=False)\n",
-    "\n",
-    "land_new.plot(ax=ax, cmap=cmap2, **opt)\n",
+    "mask_land110.plot(ax=ax, cmap=cmap2, add_colorbar=False)\n",
     "\n",
     "\n",
     "ax.set_extent([15, 75, 25, 50], ccrs.PlateCarree())\n",
@@ -543,11 +556,18 @@
     "\n",
     "ax.set_title(\"Polygon interiors are unmasked\");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -561,7 +581,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/method.ipynb
+++ b/docs/notebooks/method.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "import warnings\n",
     "\n",
-    "#warnings.filterwarnings(\"ignore\")"
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "source": [
     "## Edge behavior\n",
     "\n",
-    "The edge behavior determines how points that fall on the outline of a region are treated. It's easiest to see the edge behaviour in an\n",
+    "The edge behavior determines how points that fall on the outline of a region are treated. It's easiest to see the edge behaviour in an example.\n",
     "\n",
     "### Example\n",
     "\n",

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,6 +33,10 @@ Breaking Changes
 Enhancements
 ~~~~~~~~~~~~
 
+- Creating masks for irregular and 2D grids can be speed up considerably by installing
+  `pygeos <https://pygeos.readthedocs.io/en/stable/>`__. pygeos is an optional dependency
+  (:issue:`123`).
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/regionmask/tests/__init__.py
+++ b/regionmask/tests/__init__.py
@@ -13,5 +13,6 @@ def _importorskip(modname):
     return has, func
 
 
-has_matplotlib, requires_matplotlib = _importorskip("matplotlib")
 has_cartopy, requires_cartopy = _importorskip("cartopy")
+has_matplotlib, requires_matplotlib = _importorskip("matplotlib")
+has_pygeos, requires_pygeos = _importorskip("pygeos")

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -749,59 +749,6 @@ def test_inject_mask_docstring():
 
     result = _inject_mask_docstring(True, True)
 
-<<<<<<< HEAD
-    expected = """\
-create a 3D float mask of a set of regions for the given lat/ lon grid
-
-Parameters
-----------
-geodataframe : GeoDataFrame or GeoSeries
-    Object providing the region definitions (polygons).
-lon_or_obj : object or array_like
-    Can either be a longitude array and then ``lat`` needs to be
-    given. Or an object where the longitude and latitude can be
-    retrived as: ``lon = lon_or_obj[lon_name]`` and
-    ``lat = lon_or_obj[lat_name]``
-lat : array_like, optional
-    If ``lon_or_obj`` is a longitude array, the latitude needs to be
-    specified here.
-drop : boolean, default: True
-    If True (default) drops slices where all elements are False (i.e no
-    gridpoints are contained in a region). If False returns one slice per
-    region.
-lon_name : str, optional
-    Name of longitude in ``lon_or_obj``, default: "lon".
-lat_name : str, optional
-    Name of latgitude in ``lon_or_obj``, default: "lat"
-numbers : str, optional
-    Name of the column to use for numbering the regions.
-    This column must not have duplicates. If None (default),
-    takes ``geodataframe.index.values``.
-method : "rasterize" | "shapely" | "pygeos". Default: None
-    Method used to determine whether a gridpoint lies in a region.
-    All methods lead to the same mask. If None (default)
-    autoselects the method.
-wrap_lon : bool | 180 | 360, optional
-    Whether to wrap the longitude around, inferred automatically.
-    If the regions and the provided longitude do not have the same
-    base (i.e. one is -180..180 and the other 0..360) one of them
-    must be wrapped. This can be achieved with wrap_lon.
-    If wrap_lon is None autodetects whether the longitude needs to be
-    wrapped. If wrap_lon is False, nothing is done. If wrap_lon is True,
-    longitude data is wrapped to 360 if its minimum is smaller
-    than 0 and wrapped to 180 if its maximum is larger than 180.
-
-Returns
--------
-mask_3D : float xarray.DataArray
-
-References
-----------
-See https://regionmask.readthedocs.io/en/stable/notebooks/method.html
-"""
-
-    assert result == expected
-=======
     assert "3D" in result
     assert "2D" not in result
     assert "drop :" in result
@@ -813,4 +760,3 @@ See https://regionmask.readthedocs.io/en/stable/notebooks/method.html
     assert "3D" not in result
     assert "drop :" not in result
     assert "geodataframe" not in result
->>>>>>> master

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -8,6 +8,7 @@ from regionmask import Regions
 from regionmask.core.mask import (
     _determine_method,
     _inject_mask_docstring,
+    _mask_pygeos,
     _mask_rasterize,
     _mask_rasterize_no_offset,
     _mask_shapely,
@@ -15,6 +16,7 @@ from regionmask.core.mask import (
 )
 from regionmask.core.utils import _wrapAngle, create_lon_lat_dataarray_from_bounds
 
+from . import has_pygeos, requires_pygeos
 from .utils import (
     dummy_lat,
     dummy_lon,
@@ -25,10 +27,28 @@ from .utils import (
     expected_mask_3D,
 )
 
+MASK_FUNCS = [
+    _mask_rasterize,
+    _mask_shapely,
+    pytest.param(_mask_pygeos, marks=requires_pygeos),
+]
+
+
+MASK_METHODS = [
+    "rasterize",
+    "shapely",
+    pytest.param("pygeos", marks=requires_pygeos),
+]
+
+MASK_METHODS_IRREGULAR = [
+    "shapely",
+    pytest.param("pygeos", marks=requires_pygeos),
+]
+
 # =============================================================================
 
 
-@pytest.mark.parametrize("func", [_mask_rasterize, _mask_shapely])
+@pytest.mark.parametrize("func", MASK_FUNCS)
 def test_mask_func(func):
 
     # standard
@@ -45,7 +65,15 @@ def test_mask_func(func):
     assert np.allclose(result, expected, equal_nan=True)
 
 
-def test_mask_shapely_wrong_number_fill():
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param(_mask_rasterize, marks=pytest.mark.xfail),
+        _mask_shapely,
+        pytest.param(_mask_pygeos, marks=requires_pygeos),
+    ],
+)
+def test_mask_wrong_number_fill(func):
 
     with pytest.raises(ValueError, match="The fill value should not"):
         _mask_shapely(
@@ -56,18 +84,7 @@ def test_mask_shapely_wrong_number_fill():
         _mask_shapely(dummy_lon, dummy_lat, dummy_outlines, numbers=[5])
 
 
-@pytest.mark.xfail(reason="Not implemented")
-@pytest.mark.parametrize("numbers, fill", [[[0, 1], 0], [[0], np.NaN]])
-def test_mask_rasterize_wrong_number_fill(numbers, fill):
-    # _mask_rasterize does not raise on wrong fill numbers or on missing numbers
-
-    with pytest.raises(ValueError):
-        _mask_rasterize(
-            dummy_lon, dummy_lat, dummy_outlines_poly, numbers=numbers, fill=fill
-        )
-
-
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask(method):
 
     expected = expected_mask_2D()
@@ -75,7 +92,14 @@ def test_mask(method):
     assert np.allclose(result, expected, equal_nan=True)
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.skipif(has_pygeos, reason="Only errors if pygeos is missing")
+def test_missing_pygeos_error():
+
+    with pytest.raises(ModuleNotFoundError, match="No module named 'pygeos'"):
+        dummy_region.mask(dummy_lon, dummy_lat, method="pygeos")
+
+
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_xarray(method):
 
     expected = expected_mask_2D()
@@ -87,7 +111,7 @@ def test_mask_xarray(method):
     assert np.all(np.equal(result.lon.values, dummy_lon))
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_poly_z_value(method):
 
     outl1 = Polygon(((0, 0, 1), (0, 1, 1), (1, 1.0, 1), (1, 0, 1)))
@@ -105,11 +129,10 @@ def test_mask_poly_z_value(method):
     assert np.all(np.equal(result.lon.values, dummy_lon))
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_xarray_name(method):
 
     msk = dummy_region.mask(dummy_lon, dummy_lat, method=method)
-
     assert msk.name == "region"
 
 
@@ -146,7 +169,7 @@ def test_mask_ndim_ne_1_2(ndim):
 
 @pytest.mark.parametrize("lon_name", ["lon", "longitude"])
 @pytest.mark.parametrize("lat_name", ["lat", "latitude"])
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_obj(lon_name, lat_name, method):
 
     expected = expected_mask_2D()
@@ -160,7 +183,7 @@ def test_mask_obj(lon_name, lat_name, method):
 
 
 @pytest.mark.filterwarnings("ignore:No gridpoint belongs to any region.")
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_wrap(method):
 
     # create a test case where the outlines and the lon coordinates
@@ -195,7 +218,7 @@ def test_mask_wrap(method):
     assert np.allclose(result, expected, equal_nan=True)
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_autowrap(method):
 
     expected = expected_mask_2D()
@@ -252,10 +275,9 @@ def test_mask_autowrap(method):
 
 def test_mask_wrong_method():
 
-    msg = "Method must be None or one of 'rasterize' and 'shapely'."
+    msg = "Method must be None or one of 'rasterize', 'shapely' and 'pygeos'."
     with pytest.raises(ValueError, match=msg):
-
-        dummy_region.mask(dummy_lon, dummy_lat, method="method")
+        dummy_region.mask(dummy_lon, dummy_lat, method="wrong")
 
 
 # ======================================================================
@@ -265,10 +287,11 @@ lon_2D = [[0.5, 1.5], [0.5, 1.5]]
 lat_2D = [[0.5, 0.5], [1.5, 1.5]]
 
 
-def test_mask_2D():
+@pytest.mark.parametrize("method", MASK_METHODS_IRREGULAR)
+def test_mask_2D(method):
 
     expected = expected_mask_2D()
-    result = dummy_region.mask(lon_2D, lat_2D, method="shapely")
+    result = dummy_region.mask(lon_2D, lat_2D, method=method)
 
     assert isinstance(result, xr.DataArray)
     assert np.allclose(result, expected, equal_nan=True)
@@ -288,7 +311,8 @@ def test_mask_rasterize_irregular(lon, lat):
         dummy_region.mask(lon, lat, method="rasterize")
 
 
-def test_mask_xarray_in_out_2D():
+@pytest.mark.parametrize("method", MASK_METHODS_IRREGULAR)
+def test_mask_xarray_in_out_2D(method):
     # create xarray DataArray with 2D dims
 
     coords = {
@@ -304,7 +328,7 @@ def test_mask_xarray_in_out_2D():
 
     expected = expected_mask_2D()
     result = dummy_region.mask(
-        data, lon_name="lon_2D", lat_name="lat_2D", method="shapely"
+        data, lon_name="lon_2D", lat_name="lat_2D", method=method
     )
 
     assert isinstance(result, xr.DataArray)
@@ -367,7 +391,7 @@ def test_mask_empty():
 
 
 @pytest.mark.parametrize("drop", [True, False])
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_3D(drop, method):
 
     expected = expected_mask_3D(drop)
@@ -386,7 +410,7 @@ def test_mask_3D(drop, method):
     assert np.all(result.names.values == _dr.names)
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_3D_empty(method):
 
     with pytest.warns(UserWarning, match="No gridpoint belongs to any region."):
@@ -401,7 +425,7 @@ def test_mask_3D_empty(method):
 @pytest.mark.parametrize("lon_name", ["lon", "longitude"])
 @pytest.mark.parametrize("lat_name", ["lat", "latitude"])
 @pytest.mark.parametrize("drop", [True, False])
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_3D_obj(lon_name, lat_name, drop, method):
 
     expected = expected_mask_3D(drop)
@@ -433,10 +457,9 @@ def test_mask_3D_obj(lon_name, lat_name, drop, method):
 # create a region such that the edge falls exactly on the lat/ lon coordinates
 # ===
 
-# TODO: use func(*(-161, -29, 2),  *(75, 13, -2)) after dropping py27
-ds_US_180 = create_lon_lat_dataarray_from_bounds(*(-161, -29, 2) + (75, 13, -2))
+ds_US_180 = create_lon_lat_dataarray_from_bounds(*(-161, -29, 2), *(75, 13, -2))
 ds_US_360 = create_lon_lat_dataarray_from_bounds(
-    *(360 + -161, 360 + -29, 2) + (75, 13, -2)
+    *(360 + -161, 360 + -29, 2), *(75, 13, -2)
 )
 
 outline_180 = np.array([[-100.0, 50.0], [-100.0, 28.0], [-80.0, 28.0], [-80.0, 50.0]])
@@ -504,7 +527,7 @@ def expected_mask_interior_and_edge(ds, is_360, number=0, fill=np.NaN):
     return expected
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 @pytest.mark.parametrize(
     "regions", [r_US_180_ccw, r_US_180_cw, r_US_360_ccw, r_US_360_cw]
 )
@@ -520,7 +543,7 @@ def test_mask_edge(method, regions, ds_US, is_360):
     assert np.all(np.equal(result.lon, ds_US.lon))
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 @pytest.mark.parametrize(
     "regions",
     [r_US_hole_180_cw, r_US_hole_180_ccw, r_US_hole_360_cw, r_US_hole_360_ccw],
@@ -551,7 +574,7 @@ def test_rasterize_edge():
     assert np.allclose(result, expected, equal_nan=True)
 
 
-ds_for_45_deg = create_lon_lat_dataarray_from_bounds(*(-0.5, 16, 1) + (10.5, -0.5, -1))
+ds_for_45_deg = create_lon_lat_dataarray_from_bounds(*(-0.5, 16, 1), *(10.5, -0.5, -1))
 
 # add a small offset to y to avoid https://github.com/mapbox/rasterio/issues/1844
 outline_45_deg = np.array([[0, 10.1], [0, 0.1], [5.1, 0.1], [15.1, 10.1]])
@@ -568,6 +591,10 @@ def test_deg45_rasterize_shapely_equal(regions):
     rasterize = regions.mask(ds_for_45_deg, method="rasterize")
 
     xr.testing.assert_equal(shapely, rasterize)
+
+    if has_pygeos:
+        pygeos = regions.mask(ds_for_45_deg, method="pygeos")
+        xr.testing.assert_equal(pygeos, rasterize)
 
 
 @pytest.mark.parametrize("regions", [r_45_def_ccw, r_45_def_cw])
@@ -611,7 +638,13 @@ def test_rasterize_on_split_lon(ds_360, regions_180):
     xr.testing.assert_equal(result, expected_shapely)
 
 
-METHODS = {0: "rasterize", 1: "rasterize_flip", 2: "rasterize_split", 3: "shapely"}
+METHOD_IRREGULAR = "pygeos" if has_pygeos else "shapely"
+METHODS = {
+    0: "rasterize",
+    1: "rasterize_flip",
+    2: "rasterize_split",
+    3: METHOD_IRREGULAR,
+}
 
 equal = np.arange(0.5, 360)
 grid_2D = np.arange(10).reshape(2, 5)
@@ -663,7 +696,7 @@ lon360 = np.arange(-180, 180, 10)
 lat = np.arange(90, -91, -10)
 
 
-@pytest.mark.parametrize("method", ["rasterize", "shapely"])
+@pytest.mark.parametrize("method", MASK_METHODS)
 @pytest.mark.parametrize("regions", [r_GLOB_180, r_GLOB_360])
 @pytest.mark.parametrize("lon", [lon180, lon360])
 def test_mask_whole_grid(method, regions, lon):
@@ -683,7 +716,7 @@ create a 3D float mask of a set of regions for the given lat/ lon grid
 Parameters
 ----------
 geodataframe : GeoDataFrame or GeoSeries
-    Object providing the region definitions (outlines).
+    Object providing the region definitions (polygons).
 lon_or_obj : object or array_like
     Can either be a longitude array and then ``lat`` needs to be
     given. Or an object where the longitude and latitude can be
@@ -692,22 +725,22 @@ lon_or_obj : object or array_like
 lat : array_like, optional
     If ``lon_or_obj`` is a longitude array, the latitude needs to be
     specified here.
-drop : boolean, optional
+drop : boolean, default: True
     If True (default) drops slices where all elements are False (i.e no
     gridpoints are contained in a region). If False returns one slice per
     region.
 lon_name : str, optional
-    Name of longitude in ``lon_or_obj``. Default: "lon".
+    Name of longitude in ``lon_or_obj``, default: "lon".
 lat_name : str, optional
-    Name of latgitude in ``lon_or_obj``. Default: "lat"
+    Name of latgitude in ``lon_or_obj``, default: "lat"
 numbers : str, optional
     Name of the column to use for numbering the regions.
     This column must not have duplicates. If None (default),
     takes ``geodataframe.index.values``.
-method : "rasterize" | "shapely", optional
+method : "rasterize" | "shapely" | "pygeos". Default: None
     Method used to determine whether a gridpoint lies in a region.
-    Both methods should lead to the same result. If None (default)
-    autoselects the method depending on the grid spacing.
+    All methods lead to the same result. If None (default)
+    autoselects the method.
 wrap_lon : bool | 180 | 360, optional
     Whether to wrap the longitude around, inferred automatically.
     If the regions and the provided longitude do not have the same

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -218,7 +218,7 @@ def test_mask_wrap(method):
     assert np.allclose(result, expected, equal_nan=True)
 
 
-@pytest.mark.parametrize("method", MASK_METHODS)
+@pytest.mark.parametrize("meth", ["mask", "mask_3D"])
 def test_wrap_lon_no_error_wrap_lon_false(meth):
 
     # regions that exceed 360° longitude
@@ -243,7 +243,7 @@ def test_wrap_lon_no_error_wrap_lon_false(meth):
     np.testing.assert_equal(lat, mask.lat)
 
 
-@pytest.mark.parametrize("method", MASK_METHODS)
+@pytest.mark.parametrize("meth", ["mask", "mask_3D"])
 def test_wrap_lon_error_wrap_lon(meth):
 
     # regions that exceed 360° longitude

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -739,7 +739,7 @@ numbers : str, optional
     takes ``geodataframe.index.values``.
 method : "rasterize" | "shapely" | "pygeos". Default: None
     Method used to determine whether a gridpoint lies in a region.
-    All methods lead to the same result. If None (default)
+    All methods lead to the same mask. If None (default)
     autoselects the method.
 wrap_lon : bool | 180 | 360, optional
     Whether to wrap the longitude around, inferred automatically.

--- a/regionmask/tests/test_mask_defined_regions.py
+++ b/regionmask/tests/test_mask_defined_regions.py
@@ -1,13 +1,12 @@
 from operator import attrgetter
 
 import numpy as np
-from . import has_pygeos
 import pytest
 
 from regionmask import defined_regions
 from regionmask.core.utils import create_lon_lat_dataarray_from_bounds
 
-from . import requires_cartopy
+from . import has_pygeos, requires_cartopy
 from .utils import REGIONS, REGIONS_REQUIRING_CARTOPY, get_naturalearth_region_or_skip
 
 # =============================================================================
@@ -20,15 +19,7 @@ ds_glob_360_2 = create_lon_lat_dataarray_from_bounds(*(0, 361, 2), *(90, -91, -2
 ds_glob_360_2_part = create_lon_lat_dataarray_from_bounds(*(0, 220, 2), *(90, -91, -2))
 
 
-
-
-@pytest.mark.parametrize("region_name", REGIONS.keys())
-@pytest.mark.parametrize(
-    "ds", [ds_glob_1, ds_glob_2, ds_glob_360_2, ds_glob_360_2_part]
-)
-def test_mask_equal_defined_regions(region_name, ds):
-
-    region = attrgetter(region_name)(defined_regions)
+def _test_mask_equal_defined_regions(region, ds):
 
     rasterize = region.mask(ds, method="rasterize")
     shapely = region.mask(ds, method="shapely")
@@ -39,6 +30,17 @@ def test_mask_equal_defined_regions(region_name, ds):
         pygeos = region.mask(ds, method="pygeos")
 
         assert np.allclose(rasterize, pygeos, equal_nan=True)
+
+
+@pytest.mark.parametrize("region_name", REGIONS.keys())
+@pytest.mark.parametrize(
+    "ds", [ds_glob_1, ds_glob_2, ds_glob_360_2, ds_glob_360_2_part]
+)
+def test_mask_equal_defined_regions(region_name, ds):
+
+    region = attrgetter(region_name)(defined_regions)
+
+    _test_mask_equal_defined_regions(region, ds)
 
 
 @requires_cartopy
@@ -50,12 +52,4 @@ def test_mask_equal_defined_regions_cartopy(monkeypatch, region_name, ds):
 
     region = get_naturalearth_region_or_skip(monkeypatch, region_name)
 
-    rasterize = region.mask(ds, method="rasterize")
-    shapely = region.mask(ds, method="shapely")
-
-    assert np.allclose(rasterize, shapely, equal_nan=True)
-
-    if has_pygeos:
-        pygeos = region.mask(ds, method="pygeos")
-
-        assert np.allclose(rasterize, pygeos, equal_nan=True)
+    _test_mask_equal_defined_regions(region, ds)

--- a/regionmask/tests/test_mask_defined_regions.py
+++ b/regionmask/tests/test_mask_defined_regions.py
@@ -4,7 +4,7 @@ import pytest
 from regionmask import defined_regions
 from regionmask.core.utils import create_lon_lat_dataarray_from_bounds
 
-from . import has_cartopy
+from . import has_cartopy, has_pygeos
 
 
 def regions():
@@ -52,3 +52,8 @@ def test_mask_equal_defined_regions(region, ds):
     shapely = region.mask(ds, method="shapely")
 
     assert np.allclose(rasterize, shapely, equal_nan=True)
+
+    if has_pygeos:
+        pygeos = region.mask(ds, method="pygeos")
+
+        assert np.allclose(rasterize, pygeos, equal_nan=True)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #123
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Adds masking using pygeos (which is faster than shapely).