### PR TITLE
list available defined_regions, refactor tests

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -63,6 +63,8 @@ Internal Changes
   - Use ``pyproject.toml`` to define the installation requirements (:pull:`240`, :pull:`247`).
   - Allow installing from git archives (:pull:`240`).
   - Use setuptools-scm for automatic versioning (:pull:`240`).
+- Refactor ``test_defined_region`` and ``test_mask_equal_defined_regions`` - globally
+  define a list of all available `defined_regions` (:issue:`256`).
 
 v0.7.0 (28.07.2021)
 -------------------

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -1,76 +1,26 @@
+from operator import attrgetter
+
 import pytest
 
 from regionmask import Regions, defined_regions
 from regionmask.defined_regions import _maybe_get_column
 
 from . import has_cartopy, requires_cartopy
+from .utils import all_defined_regions
 
 
-def _defined_region(regions, n_regions):
+@pytest.mark.parametrize(
+    "region_name, n_regions", all_defined_regions(return_n=True, return_all=True)
+)
+def test_defined_region(region_name, n_regions):
 
-    assert isinstance(regions, Regions)
-    assert len(regions) == n_regions
+    region = attrgetter(region_name)(defined_regions)
+
+    assert isinstance(region, Regions)
+    assert len(region) == n_regions
 
     # currently all regions are -180..180
-    assert regions.lon_180
-
-
-def test_giorgi():
-    regions = defined_regions.giorgi
-    _defined_region(regions, 21)
-
-
-def test_srex():
-    regions = defined_regions.srex
-    _defined_region(regions, 26)
-
-
-@requires_cartopy
-def test_countries_110():
-    regions = defined_regions.natural_earth.countries_110
-    _defined_region(regions, 177)
-
-
-@requires_cartopy
-def test_countries_50():
-    regions = defined_regions.natural_earth.countries_50
-    _defined_region(regions, 241)
-
-
-@requires_cartopy
-def test_us_states_50():
-    regions = defined_regions.natural_earth.us_states_50
-    _defined_region(regions, 51)
-
-
-@requires_cartopy
-def test_us_states_10():
-    regions = defined_regions.natural_earth.us_states_10
-    _defined_region(regions, 51)
-
-
-@requires_cartopy
-def test_land_110():
-    regions = defined_regions.natural_earth.land_110
-    _defined_region(regions, 1)
-
-
-@requires_cartopy
-def test_land_50():
-    regions = defined_regions.natural_earth.land_110
-    _defined_region(regions, 1)
-
-
-@requires_cartopy
-def test_land_10():
-    regions = defined_regions.natural_earth.land_110
-    _defined_region(regions, 1)
-
-
-@requires_cartopy
-def test_ocean_basins_50():
-    regions = defined_regions.natural_earth.ocean_basins_50
-    _defined_region(regions, 119)
+    assert region.lon_180
 
 
 @requires_cartopy
@@ -80,41 +30,6 @@ def test_natural_earth_loaded_as_utf8():
     r = regions[90]
 
     assert r.name == "Río de la Plata"
-
-
-def test_ar6():
-    regions = defined_regions.ar6.all
-    _defined_region(regions, 58)
-
-
-def test_ar6_land():
-    regions = defined_regions.ar6.land
-    _defined_region(regions, 46)
-
-
-def test_ar6_ocean():
-    regions = defined_regions.ar6.ocean
-    _defined_region(regions, 15)
-
-
-def test_ar6_pre_revisions():
-    regions = defined_regions._ar6_pre_revisions.all
-    _defined_region(regions, 55)
-
-
-def test_ar6_pre_revisions_land():
-    regions = defined_regions._ar6_pre_revisions.land
-    _defined_region(regions, 43)
-
-
-def test_ar6_pre_revisions_ocean():
-    regions = defined_regions._ar6_pre_revisions.ocean
-    _defined_region(regions, 12)
-
-
-def test_ar6_pre_revisions_separate_pacific():
-    regions = defined_regions._ar6_pre_revisions.separate_pacific
-    _defined_region(regions, 58)
 
 
 def test_maybe_get_column():

--- a/regionmask/tests/test_mask_defined_regions.py
+++ b/regionmask/tests/test_mask_defined_regions.py
@@ -1,52 +1,30 @@
+from operator import attrgetter
+
 import numpy as np
 import pytest
 
 from regionmask import defined_regions
 from regionmask.core.utils import create_lon_lat_dataarray_from_bounds
 
-from . import has_cartopy
-
-
-def regions():
-    regions = [
-        defined_regions.ar6.all,
-        defined_regions.ar6.land,
-        defined_regions.ar6.ocean,
-        defined_regions.giorgi,
-        defined_regions.srex,
-    ]
-
-    if has_cartopy:
-        regions += [
-            defined_regions.natural_earth.countries_110,
-            defined_regions.natural_earth.countries_50,
-            defined_regions.natural_earth.us_states_50,
-            defined_regions.natural_earth.us_states_10,
-            defined_regions.natural_earth.land_110,
-            defined_regions.natural_earth.land_50,
-            defined_regions.natural_earth.land_10,
-            defined_regions.natural_earth.ocean_basins_50,
-        ]
-
-    return regions
-
+from .utils import all_defined_regions
 
 # =============================================================================
 
-# TODO: use func(*(-161, -29, 2),  *(75, 13, -2)) after dropping py27
-ds_glob_1 = create_lon_lat_dataarray_from_bounds(*(-180, 181, 1) + (90, -91, -1))
-ds_glob_2 = create_lon_lat_dataarray_from_bounds(*(-180, 181, 2) + (90, -91, -2))
+ds_glob_1 = create_lon_lat_dataarray_from_bounds(*(-180, 181, 1), *(90, -91, -1))
+ds_glob_2 = create_lon_lat_dataarray_from_bounds(*(-180, 181, 2), *(90, -91, -2))
 # for _mask_rasterize_flip
-ds_glob_360_2 = create_lon_lat_dataarray_from_bounds(*(0, 361, 2) + (90, -91, -2))
+ds_glob_360_2 = create_lon_lat_dataarray_from_bounds(*(0, 361, 2), *(90, -91, -2))
 # for _mask_rasterize_split
-ds_glob_360_2_part = create_lon_lat_dataarray_from_bounds(*(0, 220, 2) + (90, -91, -2))
+ds_glob_360_2_part = create_lon_lat_dataarray_from_bounds(*(0, 220, 2), *(90, -91, -2))
 
 
-@pytest.mark.parametrize("region", regions())
+@pytest.mark.parametrize("region_name", all_defined_regions(return_n=False))
 @pytest.mark.parametrize(
     "ds", [ds_glob_1, ds_glob_2, ds_glob_360_2, ds_glob_360_2_part]
 )
-def test_mask_equal_defined_regions(region, ds):
+def test_mask_equal_defined_regions(region_name, ds):
+
+    region = attrgetter(region_name)(defined_regions)
 
     rasterize = region.mask(ds, method="rasterize")
     shapely = region.mask(ds, method="shapely")

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from regionmask import Regions
 
+from . import has_cartopy
+
 outl1 = ((0, 0), (0, 1), (1, 1.0), (1, 0))
 outl2 = ((0, 1), (0, 2), (1, 2.0), (1, 1))
 # no gridpoint in outl3
@@ -33,3 +35,42 @@ def expected_mask_3D(drop):
     if drop:
         return np.array([a, b])
     return np.array([a, b, c])
+
+
+def all_defined_regions(return_n, return_all=False):
+    regions = {
+        "ar6.all": 58,
+        "ar6.land": 46,
+        "ar6.ocean": 15,
+        "giorgi": 21,
+        "srex": 26,
+    }
+
+    regions_deprecated = {
+        "_ar6_pre_revisions.all": 55,
+        "_ar6_pre_revisions.land": 43,
+        "_ar6_pre_revisions.ocean": 12,
+        "_ar6_pre_revisions.separate_pacific": 58,
+    }
+
+    regions_requiring_cartopy = {
+        "natural_earth.countries_110": 177,
+        "natural_earth.countries_50": 241,
+        "natural_earth.us_states_50": 51,
+        "natural_earth.us_states_10": 51,
+        "natural_earth.land_110": 1,
+        "natural_earth.land_50": 1,
+        "natural_earth.land_10": 1,
+        "natural_earth.ocean_basins_50": 119,
+    }
+
+    if has_cartopy:
+        regions.update(regions_requiring_cartopy)
+
+    if return_all:
+        regions.update(regions_deprecated)
+
+    if return_n:
+        return zip(regions.keys(), regions.values())
+
+    return regions.keys()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #256 
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Let's see if that put's an end to the time-outs (pytest hanging while collecting the tests). Maybe the tests will at least stop failing silently...