### PR TITLE
follow up to #255: suppress test warning

### DIFF
--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -195,6 +195,7 @@ def test_mask_wrap(method):
     assert np.allclose(result, expected, equal_nan=True)
 
 
+@pytest.mark.filterwarnings("ignore:No gridpoint belongs to any region.")
 @pytest.mark.parametrize("meth", ["mask", "mask_3D"])
 def test_wrap_lon_no_error_wrap_lon_false(meth):
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && flake8`

Follow up to #255: suppress a stray warning in the test suite.