### PR TITLE
re-pin cartopy and matplotlib

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -8,10 +8,10 @@ dependencies:
   - python
 # regionmask dependencies
   # https://github.com/SciTools/cartopy/pull/1646
-  - cartopy=0.17
+  - cartopy=0.19
   - geopandas
   # related to the cartopy issue
-  - matplotlib-base==3.2
+  - matplotlib-base=3.4
   - numpy
   - pooch
   - pygeos

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,6 +217,8 @@ man_pages = [("index", "regionmask", "regionmask Documentation", ["Mathias Hause
 # If true, show URL addresses after external links.
 # man_show_urls = False
 
+# list conda packages
+call("conda list", shell=True)
 
 # disable warnings
 warnings.filterwarnings("ignore")
@@ -231,6 +233,7 @@ notebooks = (
     "notebooks/create_own_regions",
 )
 
+print("\nBuilding notebooks:")
 for nb in notebooks:
 
     # only render notebooks if necessary
@@ -254,5 +257,3 @@ for nb in notebooks:
         ),
         shell=True,
     )
-
-call("conda list", shell=True)

--- a/docs/notebooks/geopandas.ipynb
+++ b/docs/notebooks/geopandas.ipynb
@@ -224,7 +224,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "continents_regions.plot(label=\"name\", coastlines=False);"
+    "continents_regions.plot(label=\"name\", add_coastlines=False);"
    ]
   },
   {
@@ -289,7 +289,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -303,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/mask_2D.ipynb
+++ b/docs/notebooks/mask_2D.ipynb
@@ -471,13 +471,15 @@
     "ax = plt.subplot(111, projection=proj)\n",
     "ax.set_global()\n",
     "\n",
+    "# `shading=\"flat\"` is a workaround for matplotlib 3.3 and 3.4\n",
+    "# until SciTools/cartopy#1646 is merged\n",
     "rasm.isel(time=1).Tair.plot.pcolormesh(\n",
-    "    ax=ax, x=\"xc\", y=\"yc\", transform=ccrs.PlateCarree()\n",
+    "    ax=ax, x=\"xc\", y=\"yc\", transform=ccrs.PlateCarree(), shading=\"flat\"\n",
     ")\n",
     "\n",
     "# add the abbreviation of the regions\n",
-    "regionmask.defined_regions.srex.plot(\n",
-    "    ax=ax, regions=[1, 2, 11, 12, 18], coastlines=False, label=\"abbrev\"\n",
+    "regionmask.defined_regions.srex[[1, 2, 11, 12, 18]].plot(\n",
+    "    ax=ax, add_coastlines=False, label=\"abbrev\"\n",
     ")\n",
     "\n",
     "ax.set_extent([-180, 180, 43, 90], ccrs.PlateCarree())\n",
@@ -547,8 +549,8 @@
     "\n",
     "\n",
     "# add the abbreviation of the regions\n",
-    "regionmask.defined_regions.srex.plot(\n",
-    "    ax=ax, regions=[\"NAS\"], coastlines=False, label=\"abbrev\"\n",
+    "regionmask.defined_regions.srex[[\"NAS\"]].plot(\n",
+    "    ax=ax, add_coastlines=False, label=\"abbrev\"\n",
     ")\n",
     "\n",
     "ax.set_extent([-180, 180, 45, 90], ccrs.PlateCarree())\n",
@@ -568,7 +570,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -582,7 +584,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/plotting.ipynb
+++ b/docs/notebooks/plotting.ipynb
@@ -141,7 +141,7 @@
     "    add_ocean=True,\n",
     "    resolution=\"50m\",\n",
     "    proj=proj,\n",
-    "    label=\"abbrev\",  # coastlines=False\n",
+    "    label=\"abbrev\",\n",
     ")\n",
     "\n",
     "# fine tune the extent\n",
@@ -197,7 +197,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -211,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -64,7 +64,11 @@ Docs
 - Install `regionmask` via `ci/requirements/docs.yml` on RTD using pip and update the
   packages: don't require jupyter (but ipykernel, which leads to a smaller environment),
   use new versions of sphinx and sphinx_rtd_theme (:pull:`248`).
-
+- Pin cartopy to version 0.19 and matplotlib to version 3.4 and use a (temorary) fix for
+  :issue:`165`. This allows to make use of `conda-forge/cartopy-feedstock#116
+  <https://github.com/conda-forge/cartopy-feedstock/pull/116>`__ such that natural_earth
+  shapefiles can be donwloaded again. Also added some other minor doc updates
+  (:pull:`269`).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~
@@ -73,8 +77,8 @@ Internal Changes
 
   - Moved contents of setup.py to setup.cfg (:pull:`240`).
   - Use ``pyproject.toml`` to define the installation requirements (:pull:`240`, :pull:`247`).
-  - Allow installing from git archives (:pull:`240`).
   - Use setuptools-scm for automatic versioning (:pull:`240`).
+  - Allow installing from git archives (:pull:`240`).
 - Refactor ``test_defined_region`` and ``test_mask_equal_defined_regions`` - globally
   define a list of all available `defined_regions` (:issue:`256`).
 - In the tests: downloading naturalearth regions could run forever. Make sure this does

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -77,6 +77,21 @@ def get_naturalearth_region_or_skip(monkeypatch, region_name):
     # add a timeout to cartopy.io.urlopen else it can run indefinitely
     monkeypatch.setattr(cartopy.io, "urlopen", partial(urlopen, timeout=5))
 
+    # natural earth data has moved to amazon, older version of cartopy still have the
+    # old url
+    # https://github.com/SciTools/cartopy/pull/1833
+    # https://github.com/nvkelso/natural-earth-vector/issues/445
+    # remove again once the minimum cartopy version is v0.19
+
+    _NE_URL_TEMPLATE = (
+        "https://naturalearth.s3.amazonaws.com/"
+        "{resolution}_{category}/ne_{resolution}_{name}.zip"
+    )
+
+    monkeypatch.setattr(
+        cartopy.io.shapereader.NEShpDownloader, "_NE_URL_TEMPLATE", _NE_URL_TEMPLATE
+    )
+
     try:
         region = attrgetter(region_name)(defined_regions)
     except URLError as e:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] See #165 and #268
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

---

- pin cartopy=0.19 in docs environment
- pin matplotlib=3.4 in docs environment
- monkeypatch url in old cartopy versions in the tests
- fix some of the deprecated `plot` arguments in the docs
