### PR TITLE
always wrap longitudes

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -41,6 +41,9 @@ Enhancements
   (:issue:`123`).
 - Can now create masks for regions with arbitrary coordinates e.g. for coordinate reference
   systems that are not lat/ lon based by setting ``wrap_lon=False`` (:issue:`151`).
+- The extent of the longitude coordinates is no longer checked to determine the wrap,
+  now only the extent of the mask is considered (:issue:`249`). This should allow to
+  infer ``wrap_lon`` correctly for more cases (:issue:`213`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -129,11 +129,9 @@ def _mask(
     # automatically detect whether wrapping is necessary
     if wrap_lon is None:
         msg_add = "Set `wrap_lon=False` to skip this check."
-        grid_is_180 = _is_180(lon.min(), lon.max(), msg_add=msg_add)
-
         regions_is_180 = _is_180(*lon_bounds, msg_add=msg_add)
 
-        wrap_lon_ = not regions_is_180 == grid_is_180
+        wrap_lon_ = 180 if regions_is_180 else 360
     else:
         wrap_lon_ = wrap_lon
 

--- a/regionmask/core/utils.py
+++ b/regionmask/core/utils.py
@@ -93,10 +93,10 @@ def _wrapAngle(lon, wrap_lon=True):
 
     wl = int(wrap_lon)
 
-    if wl == 180 or (lon.max() > 180 and not wl == 360):
+    if wl == 180 or (wl != 360 and lon.max() > 180):
         new_lon = _wrapAngle180(lon.copy())
 
-    if wl == 360 or (lon.min() < 0 and not wl == 180):
+    if wl == 360 or (wl != 180 and lon.min() < 0):
         new_lon = _wrapAngle360(lon.copy())
 
     # check if they are still unique

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -136,11 +136,11 @@ def test_mask_xarray_name(method):
     assert msk.name == "region"
 
 
-@pytest.mark.parametrize("ndims", [(2, 1), (1, 2), (0, 1)])
+@pytest.mark.parametrize("ndims", [(2, 1), (1, 2)])
 def test_mask_unequal_ndim(ndims):
 
-    lon = np.zeros(shape=ndims[0] * (2,))
-    lat = np.zeros(shape=ndims[1] * (2,))
+    lon = np.arange(ndims[0] * 2).reshape(ndims[0] * (2,))
+    lat = np.arange(ndims[1] * 2).reshape(ndims[1] * (2,))
 
     with pytest.raises(ValueError, match="Equal number of dimensions required"):
         dummy_region.mask(lon, lat)
@@ -762,6 +762,17 @@ def test_mask_whole_grid(method, regions, lon):
     # with wrap_lon=False the edges are not masked
     mask = regions.mask(lon, lat, method=method, wrap_lon=False)
     assert mask.sel(lat=-90).isnull().all()
+
+
+@pytest.mark.parametrize("method", MASK_METHODS)
+@pytest.mark.parametrize("regions", [r_GLOB_180, r_GLOB_360])
+def test_mask_whole_grid(method, regions):
+
+    lat = np.arange(90, -91, -2.5)
+    lon = np.arange(-300, 60, 2.5)
+    mask = regions.mask(lon, lat, method=method)
+
+    assert (mask == 0).all()
 
 
 def test_inject_mask_docstring():

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -766,7 +766,8 @@ def test_mask_whole_grid(method, regions, lon):
 
 @pytest.mark.parametrize("method", MASK_METHODS)
 @pytest.mark.parametrize("regions", [r_GLOB_180, r_GLOB_360])
-def test_mask_whole_grid(method, regions):
+def test_mask_whole_grid_unusual_lon(method, regions):
+    # https://github.com/regionmask/regionmask/issues/213
 
     lat = np.arange(90, -91, -2.5)
     lon = np.arange(-300, 60, 2.5)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #213, closes  #249
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`
