### PR TITLE
GH actions: more caching, longer timeout

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -43,9 +43,9 @@ jobs:
             ~/.cache/regionmask/
             ~/.local/share/cartopy/
           key:
-            ${{ runner.os }}-conda-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
+            ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-py${{ matrix.env }}-
+            ${{ runner.os }}-conda-py${{ matrix.python-version }}-
             ${{ runner.os }}-
 
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -20,9 +20,10 @@ jobs:
         os: ["ubuntu-latest"]
         env:
           [
-            "py36-bare-minimum",
-            "py36-min-all-deps",
+            "bare-minimum",
+            "min-all-deps",
           ]
+        python-version: ["3.6"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,7 +31,10 @@ jobs:
 
       - name: Set environment variables
         run: |
-            echo "CONDA_ENV_FILE=ci/requirements/${{ matrix.env }}.yml" >> $GITHUB_ENV
+            PY=${{ matrix.python-version }}
+            # replace "." in matrix.env
+            echo "PY=py${PY//./}" >> $GITHUB_ENV
+            echo "CONDA_ENV_FILE=ci/requirements/py${PY}-${{ matrix.env }}.yml" >> $GITHUB_ENV
       - name: Cache conda
         uses: actions/cache@v2
         with:
@@ -41,7 +45,7 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ matrix.env }}
+            ${{ runner.os }}-conda-py${{ matrix.env }}-
             ${{ runner.os }}-
 
       - uses: conda-incubator/setup-miniconda@v2
@@ -70,7 +74,7 @@ jobs:
         run: |
           python -c "import regionmask"
       - name: Run tests
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: python -u -m pytest
           --cov=regionmask
           --cov-report=xml

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -32,8 +32,8 @@ jobs:
       - name: Set environment variables
         run: |
             PY=${{ matrix.python-version }}
-            # replace "." in matrix.env
-            echo "PY=py${PY//./}" >> $GITHUB_ENV
+            # replace "." in matrix.python-version
+            PY=${PY//./}
             echo "CONDA_ENV_FILE=ci/requirements/py${PY}-${{ matrix.env }}.yml" >> $GITHUB_ENV
       - name: Cache conda
         uses: actions/cache@v2

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.env }}
+    name: py${{ matrix.python-version }}-${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
             ~/.local/share/cartopy/
           key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ hashFiles('ci/requirements/**.yml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ matrix.python-version }}-
+            ${{ runner.os }}-conda-py${{ matrix.python-version }}-
             ${{ runner.os }}-
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -33,8 +33,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{
-            hashFiles('ci/requirements/**.yml') }}
+          key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ hashFiles('ci/requirements/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-conda-${{ matrix.python-version }}-
+            ${{ runner.os }}-
       - uses: conda-incubator/setup-miniconda@v2
         with:
           channels: conda-forge

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -35,7 +35,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ hashFiles('ci/requirements/**.yml') }}
           restore-keys: |
-            ${{ runner.os }}-conda-${{ matrix.python-version }}-
+            ${{ runner.os }}-conda-py${{ matrix.python-version }}-
             ${{ runner.os }}-
       - uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
- Give the `ci-additional` and `linting` actions more chance for a cache hit.
- Also `py36-min-all-deps` still sometimes hits timeouts & creates errors. But it is running and aborting at 50% or so, so try with a longer timeout and maybe get a chance to see the errors...
