### PR TITLE
drop python 3.6 support

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -35,18 +35,18 @@ jobs:
             # replace "." in matrix.python-version
             PY=${PY//./}
             echo "CONDA_ENV_FILE=ci/requirements/py${PY}-${{ matrix.env }}.yml" >> $GITHUB_ENV
-      - name: Cache conda
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/conda_pkgs_dir
-            ~/.cache/regionmask/
-            ~/.local/share/cartopy/
-          key:
-            ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-conda-py${{ matrix.python-version }}-
-            ${{ runner.os }}-
+      # - name: Cache conda
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/conda_pkgs_dir
+      #       ~/.cache/regionmask/
+      #       ~/.local/share/cartopy/
+      #     key:
+      #       ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-conda-py${{ matrix.python-version }}-
+      #       ${{ runner.os }}-
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -35,18 +35,18 @@ jobs:
             # replace "." in matrix.python-version
             PY=${PY//./}
             echo "CONDA_ENV_FILE=ci/requirements/py${PY}-${{ matrix.env }}.yml" >> $GITHUB_ENV
-      # - name: Cache conda
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/conda_pkgs_dir
-      #       ~/.cache/regionmask/
-      #       ~/.local/share/cartopy/
-      #     key:
-      #       ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-conda-py${{ matrix.python-version }}-
-      #       ${{ runner.os }}-
+      - name: Cache conda
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/.cache/regionmask/
+            ~/.local/share/cartopy/
+          key:
+            ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ matrix.env }}-${{ hashFiles('ci/requirements/**.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-conda-py${{ matrix.python-version }}-
+            ${{ runner.os }}-
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -55,7 +55,7 @@ jobs:
           mamba-version: "*"
           activate-environment: regionmask-tests
           auto-update-conda: false
-          python-version: {{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           use-only-tar-bz2: true
 
       - name: Install conda dependencies

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -23,7 +23,7 @@ jobs:
             "bare-minimum",
             "min-all-deps",
           ]
-        python-version: ["3.6"]
+        python-version: ["3.7"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -55,7 +55,7 @@ jobs:
           mamba-version: "*"
           activate-environment: regionmask-tests
           auto-update-conda: false
-          python-version: 3.6
+          python-version: {{ matrix.python-version }}
           use-only-tar-bz2: true
 
       - name: Install conda dependencies

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -110,4 +110,4 @@ jobs:
       - name: minimum versions policy
         run: |
           mamba install -y pyyaml conda python-dateutil
-          python ci/min_deps_check.py ci/requirements/py36-min-all-deps.yml
+          python ci/min_deps_check.py ci/requirements/py37-min-all-deps.yml

--- a/ci/requirements/py37-bare-minimum.yml
+++ b/ci/requirements/py37-bare-minimum.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.6
+  - python=3.7
   - geopandas
   - numpy
   - pooch

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.6
+  - python=3.7
   - cartopy=0.17
   - geopandas=0.6
   - matplotlib-base=3.1

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python (3.6 or later)
+- Python (3.7 or later)
 - `geopandas <http://geopandas.org/>`__ (0.6 or later)
 - `numpy <http://www.numpy.org/>`__ (1.17 or later)
 - `pooch <https://www.fatiando.org/pooch/latest/>`__ (1.0 or later)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -16,6 +16,8 @@ v0.9.0 (unreleased)
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
+- Removed support for Python 3.6.
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,7 +25,7 @@ classifiers =
 packages = find:
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     geopandas >= 0.6
     numpy >= 1.17


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #251
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`
