### PR TITLE
shapely v1.8 deprecations

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -50,6 +50,7 @@ Docs
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Fix compatibility with shapely 1.8 (:pull:`291`).
 - Fix downloading naturalearth regions part 2 (see :pull:`261`): Monkeypatch the correct
   download URL and catch all ``URLError``, not only timeouts (:pull:`289`).
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -9,8 +9,8 @@ def _polygons_coords(polygons):
 
     coords = []
     for p in polygons:
-        coords += [np.asarray(p.exterior)[:, :2]] + [
-            np.asarray(i)[:, :2] for i in p.interiors
+        coords += [np.asarray(p.exterior.coords)[:, :2]] + [
+            np.asarray(i.coords)[:, :2] for i in p.interiors
         ]
 
     return coords

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -407,7 +407,7 @@ class _OneRegion:
             if isinstance(poly, MultiPolygon):
                 # find the polygon with the largest area and assig as centroid
                 area = 0
-                for p in poly:
+                for p in poly.geoms:
                     if p.area > area:
                         centroid = np.array(p.centroid.coords).squeeze()
                         area = p.area
@@ -443,7 +443,7 @@ class _OneRegion:
             if isinstance(self._polygon, Polygon):
                 polys = [self._polygon]
             else:
-                polys = list(self._polygon)
+                polys = list(self._polygon.geoms)
 
             # separate the single polygons with NaNs
             nan = np.ones(shape=(1, 2)) * np.nan

--- a/regionmask/core/utils.py
+++ b/regionmask/core/utils.py
@@ -15,7 +15,7 @@ def _flatten_polygons(polygons, error="raise"):
     polys = []
     for p in polygons:
         if isinstance(p, MultiPolygon):
-            polys += list(p)
+            polys += list(p.geoms)
         elif isinstance(p, Polygon):
             polys += [p]
         else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`
