### PR TITLE
plot: segmentize instead of subsample

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,7 +84,6 @@ Attributes
    Regions.bounds_global
    Regions.lon_180
    Regions.lon_360
-   Regions._is_polygon
 
 
 _OneRegion

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -30,6 +30,13 @@ Enhancements
   Note that only xarray arrays can be detected as unstructured grids.
   (:issue:`278`, :pull:`280`). By `Aaron Spring <https://github.com/aaronspring>`_.
 
+- The plotting methods (:py:meth:`Regions.plot` and :py:meth:`Regions.plot_regions`) now
+  use a more sophisticated logic to subsample lines on GeoAxes plots. The new method is
+  based on the eucledian distance of each segment. Per default the maximum distance of
+  each segment is 1 for lat/ lon coords - see the ``tolerance`` keyword of the plotting
+  methods. The ``subsample`` keyword is deprecated (:issue:`109`, :pull:`292`).
+
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,7 +32,7 @@ Enhancements
 
 - The plotting methods (:py:meth:`Regions.plot` and :py:meth:`Regions.plot_regions`) now
   use a more sophisticated logic to subsample lines on GeoAxes plots. The new method is
-  based on the eucledian distance of each segment. Per default the maximum distance of
+  based on the euclidean distance of each segment. Per default the maximum distance of
   each segment is 1 for lat/ lon coords - see the ``tolerance`` keyword of the plotting
   methods. The ``subsample`` keyword is deprecated (:issue:`109`, :pull:`292`).
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -56,8 +56,8 @@ def _draw_poly(ax, polygons, tolerance=None, **kwargs):
 def segmentize(coords, tolerance):
     """Adds vertices to line segments based on tolerance.
 
-    Additional vertices will be added to every line segment in an input geometry
-    so that segments are no greater than tolerance.  New vertices will evenly
+    Additional vertices will be added to every line segment in input coordinates
+    so that segments are no greater than tolerance. New vertices will evenly
     subdivide each segment.
 
 
@@ -67,7 +67,7 @@ def segmentize(coords, tolerance):
         2D coordinate array of shape N x 2
     tolerance : float
         Additional vertices will be added so that all line segments are no
-        greater than this value.  Must be greater than 0.
+        greater than this value. Must be greater than 0.
 
     See also
     --------
@@ -178,7 +178,7 @@ def _plot(
         certain maps.
 
         - None: draw original coordinates
-        - float > 0: the maximum (eucledian) lenght of each line segment.
+        - float > 0: the maximum (euclidean) length of each line segment.
         - 'auto': The tolerance is automatically determined based on the log10 of the
           largest absolute coordinate. Defaults to 1 for lat/ lon coordinates.
 
@@ -322,9 +322,9 @@ def _plot_regions(
         certain maps.
 
         - None: draw original coordinates
-        - float > 0: the maximum (eucledian) length of each line segment.
+        - float > 0: the maximum (euclidean) length of each line segment.
         - 'auto': None if a matplotlib axes is passed. If a cartopy GeoAxes is passed
-          the tolerance is automatically determined the based on the log10 of the
+          the tolerance is automatically determined based on the log10 of the
           largest absolute coordinate. Defaults to 1 for lat/ lon coordinates.
 
     Returns

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -179,8 +179,10 @@ def _plot(
 
         - None: draw original coordinates
         - float > 0: the maximum (eucledian) lenght of each line segment.
-        - 'auto': Automatically determine the tolerance based on the largest coordinate.
-          Defaults to 1 for lat/ lon coordinates.
+        - 'auto': The tolerance is automatically determined based on the log10 of the
+          largest absolute coordinate. Defaults to 1 for lat/ lon coordinates.
+
+
 
     Returns
     -------
@@ -348,6 +350,7 @@ def _plot_regions(
 
     import matplotlib.pyplot as plt
 
+    is_geoaxes = False
     try:
         import cartopy.crs as ccrs
         from cartopy.mpl import geoaxes

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -16,7 +16,13 @@ def _polygons_coords(polygons):
     return coords
 
 
-def _draw_poly(ax, polygons, subsample=False, **kwargs):
+def _get_tolerance(coords):
+
+    mx = np.max(np.abs(coords))
+    return 1 if mx == 0 else max(10 ** (int(np.log10(mx)) - 2), 1)
+
+
+def _draw_poly(ax, polygons, tolerance=None, **kwargs):
     """
     draw the outline of the regions
 
@@ -27,8 +33,11 @@ def _draw_poly(ax, polygons, subsample=False, **kwargs):
     polygons = _flatten_polygons(polygons)
     coords = _polygons_coords(polygons)
 
-    if subsample:
-        coords = [_subsample(coord) if len(coord) < 10 else coord for coord in coords]
+    if tolerance == "auto":
+        tolerance = _get_tolerance(np.concatenate(coords, 0))
+
+    if tolerance is not None:
+        coords = [segmentize(coord, tolerance) for coord in coords]
 
     color = kwargs.pop("color", "0.1")
 
@@ -44,11 +53,46 @@ def _draw_poly(ax, polygons, subsample=False, **kwargs):
     # ax.autoscale_view()
 
 
-def _subsample(outl, num=50):
-    # assumes outl is closed - i.e outl[:-1] == outl[0]
-    out = np.linspace(outl[:-1], outl[1:], num=num, endpoint=False, axis=1)
-    out = out.reshape(-1, 2)
-    return np.vstack([out, outl[-1]])
+def segmentize(coords, tolerance):
+    """Adds vertices to line segments based on tolerance.
+
+    Additional vertices will be added to every line segment in an input geometry
+    so that segments are no greater than tolerance.  New vertices will evenly
+    subdivide each segment.
+
+
+    Parameters
+    ----------
+    coords : ndarray
+        2D coordinate array of shape N x 2
+    tolerance : float
+        Additional vertices will be added so that all line segments are no
+        greater than this value.  Must be greater than 0.
+
+    See also
+    --------
+    pygeos.segmentize
+    """
+
+    coords = np.asarray(coords)
+    dist = np.sqrt(np.sum((coords[1:] - coords[:-1]) ** 2, axis=1))
+    num = np.ceil(dist / tolerance).astype(int)
+
+    if (num == 1).all():
+        return coords
+
+    out = list()
+    for i in range(len(coords) - 1):
+        if num[i] > 1:
+            out.append(
+                np.linspace(coords[i, :], coords[i + 1, :], num=num[i], endpoint=False)
+            )
+        else:
+            out.append(coords[i : i + 1, :])
+
+    out.append(coords[-1:, :])
+
+    return np.concatenate(out, 0)
 
 
 def _check_unused_kws(add, kws, feature_name, kws_name):
@@ -77,6 +121,7 @@ def _plot(
     ocean_kws=None,
     land_kws=None,
     label_multipolygon="largest",
+    tolerance="auto",
     **kwargs,
 ):
     """
@@ -113,11 +158,7 @@ def _plot(
         Specify the resolution of the coastline and the ocean dataset.
         See cartopy for details.
     subsample : None or bool, default: None
-        If True subsamples the outline of the coords to make better
-        looking plots on certain maps. If False does not subsample.
-        If None, infers the subsampling -> if the input is given as
-        array subsamples if it is given as (Multi)Polygons does not
-        subsample.
+        Deprecated, use tolerance.
     add_land : bool, default: False
         If true adds the land feature. See land_kws.
     coastline_kws : dict, default: None
@@ -132,6 +173,14 @@ def _plot(
     label_multipolygon : 'largest' | 'all', default: 'largest'.
         If 'largest' only adds a text label for the largest Polygon of a
         MultiPolygon. If 'all' adds text labels to all of them.
+    tolerance : None | 'auto' | float, default: 'auto'.
+        Maximum length of drawn line segments. Can lead to better looking plots on
+        certain maps.
+
+        - None: draw original coordinates
+        - float > 0: the maximum (eucledian) lenght of each line segment.
+        - 'auto': Automatically determine the tolerance based on the largest coordinate.
+          Defaults to 1 for lat/ lon coordinates.
 
     Returns
     -------
@@ -218,6 +267,7 @@ def _plot(
         text_kws=text_kws,
         subsample=subsample,
         label_multipolygon=label_multipolygon,
+        tolerance=tolerance,
     )
 
     return ax
@@ -234,6 +284,7 @@ def _plot_regions(
     text_kws=None,
     subsample=None,
     label_multipolygon="largest",
+    tolerance="auto",
 ):
     """
     plot map with with srex regions
@@ -259,15 +310,20 @@ def _plot_regions(
     text_kws : dict, optional
         Arguments passed to the labels (ax.text).
     subsample : None or bool, optional
-        If True subsamples the outline of the coords to make better
-        looking plots on certain maps. If False does not subsample.
-        If None, infers the subsampling -> if the input is given as
-        array subsamples if it is given as (Multi)Polygons does not
-        subsample.
+        Deprecated, use tolerance.
     label_multipolygon : 'largest' | 'all', optional
         If 'largest' only adds a text label for the largest Polygon of a
         MultiPolygon. If 'all' adds text labels to all of them. Default:
         'largest'.
+    tolerance : None | 'auto' | float, default: 'auto'.
+        Maximum length of drawn line segments. Can lead to better looking plots on
+        certain maps.
+
+        - None: draw original coordinates
+        - float > 0: the maximum (eucledian) length of each line segment.
+        - 'auto': None if a matplotlib axes is passed. If a cartopy GeoAxes is passed
+          the tolerance is automatically determined the based on the log10 of the
+          largest absolute coordinate. Defaults to 1 for lat/ lon coordinates.
 
     Returns
     -------
@@ -284,15 +340,21 @@ def _plot_regions(
     else:
         regions = "all"
 
+    if subsample is not None:
+        warnings.warn(
+            "The 'subsample' keyword has been deprecated. Use ``tolerance`` instead.",
+            FutureWarning,
+        )
+
     import matplotlib.pyplot as plt
 
     try:
         import cartopy.crs as ccrs
         from cartopy.mpl import geoaxes
 
-        has_cartopy = True
+        is_geoaxes = isinstance(ax, geoaxes.GeoAxes)
     except ImportError:
-        has_cartopy = False
+        pass
 
     if label_multipolygon not in ["all", "largest"]:
         raise ValueError("'label_multipolygon' must be one of 'all' and 'largest'")
@@ -302,7 +364,7 @@ def _plot_regions(
     if ax is None:
         ax = plt.gca()
 
-    if has_cartopy and isinstance(ax, geoaxes.GeoAxes):
+    if is_geoaxes:
         trans = ccrs.PlateCarree()
     else:
         trans = ax.transData
@@ -315,18 +377,18 @@ def _plot_regions(
     if np.isscalar(regions):
         regions = [regions]
 
-    if subsample is None:
-        subsample = not self._is_polygon
-
     if line_kws is None:
         line_kws = dict()
 
     if text_kws is None:
         text_kws = dict()
 
+    if tolerance == "auto" and not is_geoaxes:
+        tolerance = None
+
     # draw the outlines
     polygons = [self[i].polygon for i in regions]
-    _draw_poly(ax, polygons, subsample=subsample, transform=trans, **line_kws)
+    _draw_poly(ax, polygons, tolerance=tolerance, transform=trans, **line_kws)
 
     if add_label:
 

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -216,11 +216,6 @@ class Regions:
         return self.combiner("centroid")
 
     @property
-    def _is_polygon(self):
-        """is there at least one region was passed as (Multi)Polygon"""
-        return np.any(np.array(self.combiner("_is_polygon")))
-
-    @property
     def bounds(self):
         """list of the bounds of the regions (min_lon, min_lat, max_lon, max_lat)"""
         return self.combiner("bounds")
@@ -384,9 +379,9 @@ class _OneRegion:
         self.name = name
         self.abbrev = abbrev
 
-        self._is_polygon = isinstance(outline, (Polygon, MultiPolygon))
+        _is_polygon = isinstance(outline, (Polygon, MultiPolygon))
 
-        if self._is_polygon:
+        if _is_polygon:
             self._polygon = outline
             self._coords = None
         else:

--- a/regionmask/tests/__init__.py
+++ b/regionmask/tests/__init__.py
@@ -1,4 +1,5 @@
 import importlib
+from distutils.version import LooseVersion
 
 import pytest
 
@@ -16,3 +17,13 @@ def _importorskip(modname):
 has_cartopy, requires_cartopy = _importorskip("cartopy")
 has_matplotlib, requires_matplotlib = _importorskip("matplotlib")
 has_pygeos, requires_pygeos = _importorskip("pygeos")
+
+has_geos_3_10 = False
+if has_pygeos:
+    import pygeos
+
+    has_geos_3_10 = LooseVersion(pygeos.geos_version_string) > LooseVersion("3.10")
+
+requires_geos_3_10 = pytest.mark.skipif(
+    not has_geos_3_10, reason="requires geos > 3.10.0"
+)

--- a/regionmask/tests/test_segmentize.py
+++ b/regionmask/tests/test_segmentize.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+
+from regionmask.core.plot import _get_tolerance, segmentize
+
+from . import requires_geos_3_10
+
+
+def test_get_tolerance():
+
+    assert _get_tolerance(0) == 1
+    assert _get_tolerance(-1) == 1
+    assert _get_tolerance(360) == 1
+    assert _get_tolerance([-1, 20]) == 1
+    assert _get_tolerance(999) == 1
+    assert _get_tolerance(1000) == 10
+    assert _get_tolerance([-1000, 10]) == 10
+    assert _get_tolerance(10000) == 100
+    assert _get_tolerance(10 ** 8) == 10 ** 6
+
+
+def test_segmentize():
+
+    zeros = np.zeros(51)
+
+    result = segmentize([[0, 0], [1, 0]], tolerance=1 / 50)
+    expected = np.vstack((np.arange(0, 1.01, 0.02), zeros)).T
+    assert np.allclose(expected, result)
+
+    result = segmentize([[0, 1], [0, 0]], tolerance=1 / 50)
+    expected = np.vstack((zeros, np.arange(1, -0.01, -0.02))).T
+    assert np.allclose(expected, result)
+
+    outl1 = ((0, 0), (0, 1), (1, 1.0), (1, 0))
+
+    # polygons are automatically closed
+    outl1_closed = outl1 + outl1[:1]
+
+    result = segmentize(outl1_closed, tolerance=0.5)
+
+    expected = [
+        [0, 0],
+        [0, 0.5],
+        [0, 1],
+        [0.5, 1],
+        [1, 1.0],
+        [1, 0.5],
+        [1, 0],
+        [0.5, 0],
+        [0, 0],
+    ]
+
+    assert np.allclose(expected, result)
+
+
+@pytest.mark.parametrize("number", [1, 2, 5, 20, 100])
+def test_segmentize_n_segments(number):
+
+    zeros = np.zeros(number + 1)
+
+    result = segmentize([[0, 0], [1, 0]], tolerance=1 / number)
+    expected = np.vstack((np.arange(0, 1.0001, 1 / number), zeros)).T
+    assert np.allclose(expected, result)
+
+
+def test_segmentize_smaller():
+
+    result = segmentize([[0, 0], [0, 1]], tolerance=0.3)
+    expected = [
+        [0, 0.0],
+        [0, 0.25],
+        [0, 0.50],
+        [0, 0.75],
+        [0, 1.0],
+    ]
+
+    np.testing.assert_allclose(expected, result)
+
+
+COORDS = (
+    ([[0, 0], [0, 1]]),
+    ([[0, 0], [20, 8]]),
+    ([[0, 0], [-20.5698, 8.3]]),
+    ([[-10, -5], [8, 8.3]]),
+)
+
+
+@requires_geos_3_10
+@pytest.mark.parametrize("coords", COORDS)
+@pytest.mark.parametrize("tolerance", [0.3, 1.0, 2.7852])
+def test_segmentize_pygeos(coords, tolerance):
+
+    import pygeos
+    import pygeos.testing
+
+    expected = pygeos.segmentize(pygeos.linestrings(coords), tolerance)
+    result = segmentize(coords, tolerance)
+    result = pygeos.linestrings(result)
+
+    pygeos.testing.assert_geometries_equal(result, expected)

--- a/regionmask/tests/test_segmentize.py
+++ b/regionmask/tests/test_segmentize.py
@@ -53,6 +53,16 @@ def test_segmentize():
     assert np.allclose(expected, result)
 
 
+def test_segmentize_mixed_length():
+    # only one of the segements needs to be split
+
+    outl = ((0, 0), (0, 1), (0, 5))
+    result = segmentize(outl, tolerance=1)
+    expected = ((0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5))
+
+    assert np.allclose(expected, result)
+
+
 @pytest.mark.parametrize("number", [1, 2, 5, 20, 100])
 def test_segmentize_n_segments(number):
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #109
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Use a better logic to create nice looking plots on curved cartopy maps - split segments based on it's euclidean distance instead of blindly cutting it into 50 pieces irrespective of it's length. This is only applied on `cartopy.geoaxes.GeoAxes`. Per default  the maximum segment length is 1 (for lat/ lon coords).

The exact formula is given as
```python
mx = np.max(np.abs(coords))
tolerance = 1 if mx == 0 else max(10 ** (int(np.log10(mx)) - 2), 1)
```

