### PR TITLE
refactor mask_to_dataarray

### DIFF
--- a/ci/requirements/py37-bare-minimum.yml
+++ b/ci/requirements/py37-bare-minimum.yml
@@ -9,7 +9,7 @@ dependencies:
   - pooch
   - rasterio
   - setuptools
-  - xarray<0.19.0
+  - xarray
 # for testing
   - pytest
   - pytest-cov

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,10 +17,16 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 
 - Removed support for Python 3.6.
+- Passing mixed type coordinates to :py:meth:`Regions.mask` and :py:meth:`Regions.mask_3D`
+  is no longer supported, i.e. can no longer pass lon as numpy array and lat as
+  DataArray (:pull:`293`).
+- The mask now has non-dimension coordinates when 2D numpy arrays are passed as lat and
+  lon coords (:pull:`293`).
 
 Enhancements
 ~~~~~~~~~~~~
-- Works with unstructured 1D grids such as:
+- :py:meth:`Regions.mask` and :py:meth:`Regions.mask_3D` now works with unstructured 1D
+  grids such as:
 
   - `ICON <https://code.mpimet.mpg.de/projects/iconpublic>`_
   - `FESOM <https://fesom.de/>`_
@@ -51,6 +57,10 @@ New regions
 Bug Fixes
 ~~~~~~~~~
 
+- The name of lon and lat coordinates when passed as single elements is now repected when
+  creating masks i.e. for ``region.mask(ds.longitude, ds.longitude)`` (:issue:`129`,
+  :pull:`293`).
+
 Docs
 ~~~~
 
@@ -60,6 +70,7 @@ Internal Changes
 - Fix compatibility with shapely 1.8 (:pull:`291`).
 - Fix downloading naturalearth regions part 2 (see :pull:`261`): Monkeypatch the correct
   download URL and catch all ``URLError``, not only timeouts (:pull:`289`).
+- Rewrote the function to create the mask `DataArray` (:issue:`168`, :pull:`293`).
 
 v0.8.0 (08.09.2021)
 -------------------

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -316,7 +316,7 @@ def mask_to_dataarray(mask, lon_or_obj, lat=None, lon_name="lon", lat_name="lat"
 
     ds = lat.coords.merge(lon.coords)
 
-    if LooseVersion(xr.__version__) < LooseVersion("0.18.1"):
+    if LooseVersion(xr.__version__) < LooseVersion("0.19"):
         # ds.dims were a SortedDict but we rely on the insertion order here
         dims = ds._dims.keys()
     else:

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -1,4 +1,5 @@
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 import xarray as xr
@@ -314,7 +315,12 @@ def mask_to_dataarray(mask, lon_or_obj, lat=None, lon_name="lon", lat_name="lat"
         lon, lat = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
 
     ds = lat.coords.merge(lon.coords)
-    dims = ds.dims.keys()
+
+    if LooseVersion(xr.__version__) < LooseVersion("0.18.1"):
+        # ds.dims were a SortedDict but we rely on the insertion order here
+        dims = ds._dims.keys()
+    else:
+        dims = ds.dims.keys()
 
     return ds.assign(region=(dims, mask)).region
 

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -29,7 +29,7 @@ Parameters
     Can either be a longitude array and then ``lat`` needs to be
     given. Or an object where the longitude and latitude can be
     retrived as: ``lon = lon_or_obj[lon_name]`` and
-    ``lat = lon_or_obj[lat_name]``
+    ``lat = lon_or_obj[lat_name]``.
 lat : array_like, optional
     If ``lon_or_obj`` is a longitude array, the latitude needs to be
     specified here.
@@ -120,7 +120,6 @@ def _mask(
         raise ValueError("'numbers' must be numeric")
 
     lat_orig = lat
-
     lon, lat = _extract_lon_lat(lon_or_obj, lat, lon_name, lat_name)
 
     # determine whether unstructured grid
@@ -130,8 +129,6 @@ def _mask(
         if len(lon.dims) == 1 and len(lat.dims) == 1:
             if lon.name != lon.dims[0] and lat.name != lat.dims[0]:
                 is_unstructured = True
-                lat_orig = lat
-                lon_orig = lon
 
     lon = np.asarray(lon)
     lat = np.asarray(lat)
@@ -145,7 +142,6 @@ def _mask(
     else:
         wrap_lon_ = wrap_lon
 
-    lon_orig = lon.copy()
     if wrap_lon_:
         lon = _wrapAngle(lon, wrap_lon_, is_unstructured=is_unstructured)
 
@@ -185,20 +181,7 @@ def _mask(
             mask, lon, lat, outlines, numbers, is_unstructured=is_unstructured
         )
 
-    # create an xr.DataArray
-    if lon.ndim == 1:
-        if is_unstructured:
-            mask = _create_xarray(
-                mask, lon_orig, lat_orig, lon_name, lat_name, is_unstructured
-            )
-        else:
-            mask = _create_xarray(
-                mask, lon_orig, lat, lon_name, lat_name, is_unstructured
-            )
-    else:
-        mask = _create_xarray_2D(mask, lon_or_obj, lat_orig, lon_name, lat_name)
-
-    return mask
+    return mask_to_dataarray(mask, lon_or_obj, lat_orig, lon_name, lat_name)
 
 
 def _mask_2D(
@@ -320,61 +303,36 @@ def _extract_lon_lat(lon_or_obj, lat, lon_name, lat_name):
     return lon, lat
 
 
-def _create_xarray(mask, lon, lat, lon_name, lat_name, is_unstructured):
-    """create an xarray DataArray"""
-    if is_unstructured:
-        # lat is xr.DataArray to retrieve cell_name
-        cell_name = lat.dims[0]
-        mask = xr.DataArray(
-            mask,
-            coords={
-                cell_name: lat.coords[cell_name],
-                "lat": (cell_name, lat.values),
-                "lon": (cell_name, lon),
-            },
-            dims=cell_name,
-            name="region",
-        )
-    else:
-        coords = {lat_name: lat, lon_name: lon}
-        mask = xr.DataArray(
-            mask, coords=coords, dims=(lat_name, lon_name), name="region"
-        )
+def mask_to_dataarray(mask, lon_or_obj, lat=None, lon_name="lon", lat_name="lat"):
 
-    return mask
+    lon, lat = _extract_lon_lat(lon_or_obj, lat, lon_name, lat_name)
+
+    if sum(isinstance(c, xr.DataArray) for c in (lon, lat)) == 1:
+        raise ValueError("Cannot handle coordinates with mixed types!")
+
+    if not isinstance(lon, xr.DataArray) or not isinstance(lat, xr.DataArray):
+        lon, lat = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
+
+    ds = lat.coords.merge(lon.coords)
+    dims = ds.dims.keys()
+
+    return ds.assign(region=(dims, mask)).region
 
 
-def _create_xarray_2D(mask, lon_or_obj, lat, lon_name, lat_name):
-    """create an xarray DataArray for 2D fields"""
+def _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name):
+    # TODO: simplify once passing lon_name and lat_name is no longer supported
 
-    lon2D, lat2D = _extract_lon_lat(lon_or_obj, lat, lon_name, lat_name)
+    dims2D = (f"{lat_name}_idx", f"{lon_name}_idx")
 
-    if isinstance(lon2D, xr.DataArray):
-        dim1D_names = lon2D.dims
-        dim1D_0 = lon2D[dim1D_names[0]]
-        dim1D_1 = lon2D[dim1D_names[1]]
-    else:
-        dim1D_names = (lon_name + "_idx", lat_name + "_idx")
-        dim1D_0 = np.arange(np.array(lon2D).shape[0])
-        dim1D_1 = np.arange(np.array(lon2D).shape[1])
+    lon = np.asarray(lon)
+    dims = dims2D if lon.ndim == 2 else lon_name
+    lon = xr.Dataset(coords={lon_name: (dims, lon)})
 
-    # dict with the coordinates
-    coords = {
-        dim1D_names[0]: dim1D_0.data,
-        dim1D_names[1]: dim1D_1.data,
-        lat_name: (
-            dim1D_names,
-            lat2D.data if isinstance(lat2D, xr.DataArray) else lat2D,
-        ),
-        lon_name: (
-            dim1D_names,
-            lon2D.data if isinstance(lon2D, xr.DataArray) else lon2D,
-        ),
-    }
+    lat = np.asarray(lat)
+    dims = dims2D if lat.ndim == 2 else lat_name
+    lat = xr.Dataset(coords={lat_name: (dims, lat)})
 
-    mask = xr.DataArray(mask, coords=coords, dims=dim1D_names)
-
-    return mask
+    return lon, lat
 
 
 def _mask_edgepoints_shapely(

--- a/regionmask/tests/test_create_dataarray.py
+++ b/regionmask/tests/test_create_dataarray.py
@@ -1,0 +1,135 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from regionmask.core.mask import _numpy_coords_to_dataarray, mask_to_dataarray
+
+
+def test_mask_to_dataarray_mixed_types():
+
+    ds = xr.Dataset(coords={"lon": [0], "lat": [0]})
+
+    with pytest.raises(ValueError, match="Cannot handle coordinates with mixed types!"):
+        mask_to_dataarray(None, ds.lon.values, ds.lon)
+
+    with pytest.raises(ValueError, match="Cannot handle coordinates with mixed types!"):
+        mask_to_dataarray(None, ds.lon, ds.lon.values)
+
+
+def create_test_datasets():
+
+    mask = np.arange(4).reshape(2, 2)
+    mask1D = np.arange(2)
+
+    lon = [0, 1]
+    lat = [2, 3]
+
+    lon_2D = [[0, 1], [0, 1]]
+    lat_2D = [[1, 1], [0, 0]]
+
+    ds0 = xr.Dataset(coords={"lon": lon, "lat": lat})
+    ds1 = xr.Dataset(coords={"longitude": lon, "latitude": lat})
+    ds2 = xr.Dataset(coords={"lon": ("cells", lon), "lat": ("cells", lat)})
+    ds3 = xr.Dataset(
+        coords={"lon": ("cells", lon), "lat": ("cells", lat), "cells": ["a", "b"]}
+    )
+    ds4 = xr.Dataset(coords={"lon": (("y", "x"), lon_2D), "lat": (("y", "x"), lat_2D)})
+    ds5 = xr.Dataset(
+        coords={
+            "lon": (("y", "x"), lon_2D),
+            "lat": (("y", "x"), lat_2D),
+            "x": ["x0", "x1"],
+            "y": ["y0", "y1"],
+        }
+    )
+
+    DATASETS = (
+        (ds0, "lon", "lat", mask),
+        (ds1, "longitude", "latitude", mask),
+        (ds2, "lon", "lat", mask1D),
+        (ds3, "lon", "lat", mask1D),
+        (ds4, "lon", "lat", mask),
+        (ds5, "lon", "lat", mask),
+    )
+    return DATASETS
+
+
+@pytest.mark.parametrize("ds, lon_name, lat_name, mask", create_test_datasets())
+def test_mask_to_dataarray_ds_name(ds, lon_name, lat_name, mask):
+
+    actual = mask_to_dataarray(mask, ds, None, lon_name, lat_name)
+    actual = actual.coords.to_dataset()
+    expected = ds.coords.to_dataset()
+    xr.testing.assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("ds, lon_name, lat_name, mask", create_test_datasets())
+def test_mask_to_dataarray_ds_indiv(ds, lon_name, lat_name, mask):
+
+    actual = mask_to_dataarray(mask, ds[lon_name], ds[lat_name])
+    actual = actual.coords.to_dataset()
+    expected = ds.coords.to_dataset()
+    xr.testing.assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("lon", ([0, 1], np.array([0.1, 2.3])))
+@pytest.mark.parametrize("lat", ([2, 3], np.array([-1.75, 23.85])))
+@pytest.mark.parametrize("lon_name", ("lon", "longitude"))
+@pytest.mark.parametrize("lat_name", ("lat", "latitude"))
+def test_mask_to_dataarray_numpy_1D(lon, lat, lon_name, lat_name):
+
+    mask = np.arange(4).reshape(2, 2)
+    actual = mask_to_dataarray(mask, lon, lat, lon_name, lat_name)
+    expected = xr.DataArray(
+        mask, dims=(lat_name, lon_name), coords={lat_name: lat, lon_name: lon}
+    )
+    xr.testing.assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("lon_name", ("lon", "longitude", "x"))
+@pytest.mark.parametrize("lat_name", ("lat", "latitude", "y"))
+def test_mask_to_dataarray_numpy_2D(lon_name, lat_name):
+
+    lon = [[0, 1], [0, 1]]
+    lat = [[1, 1], [0, 0]]
+
+    mask = np.arange(4).reshape(2, 2)
+    actual = mask_to_dataarray(mask, lon, lat, lon_name, lat_name)
+    dims = (f"{lat_name}_idx", f"{lon_name}_idx")
+    expected = xr.DataArray(
+        mask, dims=dims, coords={lat_name: (dims, lat), lon_name: (dims, lon)}
+    )
+    xr.testing.assert_equal(expected, actual)
+
+
+@pytest.mark.parametrize("lon_name", ("lon", "longitude", "x"))
+@pytest.mark.parametrize("lat_name", ("lat", "latitude", "y"))
+def test_numpy_coords_to_dataarray_1D(lon_name, lat_name):
+
+    lon = [0, 1]
+    lat = [0, 1]
+
+    lon_actual, lat_actual = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
+
+    lon_expected = xr.Dataset(coords={lon_name: lon})
+    lat_expected = xr.Dataset(coords={lat_name: lat})
+
+    xr.testing.assert_equal(lon_expected, lon_actual)
+    xr.testing.assert_equal(lat_expected, lat_actual)
+
+
+@pytest.mark.parametrize("lon_name", ("lon", "longitude", "x"))
+@pytest.mark.parametrize("lat_name", ("lat", "latitude", "y"))
+def test_numpy_coords_to_dataarray_2D(lon_name, lat_name):
+
+    lon = [[0, 1]]
+    lat = [[0, 1]]
+
+    lon_actual, lat_actual = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
+
+    dims = (f"{lat_name}_idx", f"{lon_name}_idx")
+    lon_expected = xr.Dataset(coords={lon_name: (dims, lon)})
+    lat_expected = xr.Dataset(coords={lat_name: (dims, lat)})
+
+    xr.testing.assert_equal(lon_expected, lon_actual)
+    xr.testing.assert_equal(lat_expected, lat_actual)

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -112,6 +112,22 @@ def test_mask_xarray(method):
 
 
 @pytest.mark.parametrize("method", MASK_METHODS)
+def test_mask_xr_keep_name(method):
+
+    ds = xr.Dataset(coords={"longitude": dummy_lon, "latitude": dummy_lat})
+
+    expected = expected_mask_2D()
+    result = dummy_region.mask(ds.longitude, ds.latitude, method=method)
+
+    assert isinstance(result, xr.DataArray)
+    assert np.allclose(result, expected, equal_nan=True)
+    assert "longitude" in ds.coords
+    assert "latitude" in ds.coords
+    assert np.all(np.equal(result.latitude.values, dummy_lat))
+    assert np.all(np.equal(result.longitude.values, dummy_lon))
+
+
+@pytest.mark.parametrize("method", MASK_METHODS)
 def test_mask_poly_z_value(method):
 
     outl1 = Polygon(((0, 0, 1), (0, 1, 1), (1, 1.0, 1), (1, 0, 1)))


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #129
 - [x] Closes #168
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

I knew there had to be a more elegant way to create the `DataArray` of the mask. Now - when `xr.DataArray` obejects are passed as `lon` and `lat` - it's only 3 lines :blush:. The numpy arrays add some complication but that cannot be avoided.