### PR TITLE
fix: typo in docs (#303)

### DIFF
--- a/docs/notebooks/mask_2D.ipynb
+++ b/docs/notebooks/mask_2D.ipynb
@@ -110,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function `mask` determines which gripoints lie within the polygon making up the each region:"
+    "The function `mask` determines which gridpoints lie within the polygon making up the each region:"
    ]
   },
   {


### PR DESCRIPTION
Just a small typo correction. Thanks for your work.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
