### PR TITLE
deprecate ar6 _pre_revisions regions

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -64,6 +64,10 @@ Enhancements
 Deprecations
 ~~~~~~~~~~~~
 
+- The ``regionmask.defined_regions._ar6_pre_revisions`` regions are deprecated. The
+  ``regionmask.defined_regions.ar6`` regions should be used instead
+  (:issue:`314`, :pull:`320`).
+
 New regions
 ~~~~~~~~~~~
 

--- a/regionmask/defined_regions/_ar6_pre_revisions.py
+++ b/regionmask/defined_regions/_ar6_pre_revisions.py
@@ -1,3 +1,5 @@
+import warnings
+
 import geopandas as gp
 from shapely import geometry
 
@@ -37,6 +39,11 @@ The region numbers for ``all``, ``land``, and ``ocean`` are consistent. The
 region numbers for ``separate_pacific`` and all others are not.
 
 """
+
+DEPRECATION = (
+    "The ``_ar6_pre_revisions`` regions are deprecated and will be removed in a future "
+    "release."
+)
 
 
 def _combine_to_multipolygon(df, column, *names):
@@ -159,6 +166,7 @@ class ar6_pre_revisions_cls:
 
     @property
     def all(self):
+        warnings.warn(DEPRECATION, FutureWarning)
         if self._all is None:
 
             self._all = from_geopandas(
@@ -177,6 +185,9 @@ class ar6_pre_revisions_cls:
             r = self.all[land]
             r.name = self._name + " (land only)"
             self._land = r
+        else:
+            warnings.warn(DEPRECATION, FutureWarning)
+
         return self._land
 
     @property
@@ -185,10 +196,13 @@ class ar6_pre_revisions_cls:
             r = self.all[ocean]
             r.name = self._name + " (ocean only)"
             self._ocean = r
+        else:
+            warnings.warn(DEPRECATION, FutureWarning)
         return self._ocean
 
     @property
     def separate_pacific(self):
+        warnings.warn(DEPRECATION, FutureWarning)
         if self._separate_pacific is None:
             # need to fix the duplicates
             df = self._df.copy()

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -34,7 +34,9 @@ def test_defined_region(region_name, n_regions):
 @pytest.mark.parametrize("region_name, n_regions", REGIONS_DEPRECATED.items())
 def test_defined_region_deprecated(region_name, n_regions):
 
-    region = attrgetter(region_name)(defined_regions)
+    match = "The ``_ar6_pre_revisions`` regions are deprecated"
+    with pytest.warns(FutureWarning, match=match):
+        region = attrgetter(region_name)(defined_regions)
 
     _test_region(region, n_regions)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #314
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`
