### PR TITLE
add_packaging as adependency

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -12,6 +12,7 @@ dependencies:
   - matplotlib-base
   - numpy
   - pooch
+  - packaging
   - pygeos
   - rasterio
   - xarray

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - geopandas
   - matplotlib-base
   - numpy
+  - packaging
   - pooch
   - pygeos
   - rasterio

--- a/ci/requirements/py37-bare-minimum.yml
+++ b/ci/requirements/py37-bare-minimum.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.7
   - geopandas
   - numpy
+  - packaging
   - pooch
   - rasterio
   - setuptools

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -9,6 +9,7 @@ dependencies:
   - matplotlib-base=3.2
   - numpy=1.17
   - pandas=1.2
+  - packaging=20.0
   - pooch=1.2
   - pygeos=0.9
   - rasterio=1.1

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,6 +7,7 @@ Required dependencies
 - Python (3.7 or later)
 - `geopandas <http://geopandas.org/>`__ (0.7 or later)
 - `numpy <http://www.numpy.org/>`__ (1.17 or later)
+- `packaging <https://packaging.pypa.io/en/latest/>`__ (20.0 or later)
 - `pooch <https://www.fatiando.org/pooch/latest/>`__ (1.2 or later)
 - `rasterio <https://rasterio.readthedocs.io/>`__ (1.1 or later)
 - `shapely <http://toblerity.org/shapely/>`__ (1.7 or later)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -112,6 +112,7 @@ Internal Changes
 - Follow up to :pull:`294` - fix wrong dimension order for certain conditions (:issue:`295`).
 - Refactor `test_mask` - make use of ``xr.testing.assert_equal`` and simplify some
   elements (:pull:`297`).
+- Add `packaging` as a dependency (:issue:`324`, :pull:`328`).
 
 v0.8.0 (08.09.2021)
 -------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 
 geopandas >= 0.7
 numpy >= 1.17
+packaging >= 20.0
 pooch >= 1.2
 rasterio >= 1.1
 shapely >= 1.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     numpy >= 1.17
     pooch >= 1.2
     rasterio >= 1.1
+    packaging >= 20.0
     setuptools >= 40.4  # for pkg_resources
     shapely >= 1.7
     xarray >= 0.15


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #324
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

I was tempted to just remove the one usage of packaging in regionmask but I expect we will you this more in the future (e.g. once shapely 2.0 comes out).