### PR TITLE
fix typos (using codespell)

### DIFF
--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -15,7 +15,7 @@ These instructions assume that `upstream` refers to the main repository
  2. Maybe write a release summary: ~50 words describing the high level features.
  3. Look over whats-new.rst and the docs. Make sure "What's New" is complete
     (check the date!) and add the release summary at the top.
- 4. Open a PR with the release summary and whats new changes.
+ 4. Open a PR with the release summary and what's new changes.
  5. After merging, again ensure your master branch is synced to upstream:
      ```sh
      git pull upstream master

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -16,7 +16,7 @@ dependencies:
   - pygeos
   - rasterio
   - xarray
-# depencies for the examples
+# dependencies for the examples
   - cftime
   - netcdf4
 # for regionmask intake example

--- a/docs/README_ipynp_for_RTD
+++ b/docs/README_ipynp_for_RTD
@@ -20,7 +20,7 @@ Changes to Makefile
 # define targets
 TUTORIALS = tutorials/plotting.rst tutorials/mask_numpy.rst tutorials/mask_xarray.rst
 
-# recipie to create targets
+# recipe to create targets
 tutorials/%.rst: _static/notebooks/%.ipynb
         cd tutorials;ipython nbconvert --template tutorial_rst --to rst ../$<
 

--- a/docs/notebooks/mask_2D.ipynb
+++ b/docs/notebooks/mask_2D.ipynb
@@ -214,7 +214,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    ".. note:: ``regionmask`` automatically detects wether the longitude needs to be wrapped around, i.e. if the regions extend from -180° E to 180° W, while the grid goes from 0° to 360° W as in our example:"
+    ".. note:: ``regionmask`` automatically detects whether the longitude needs to be wrapped around, i.e. if the regions extend from -180° E to 180° W, while the grid goes from 0° to 360° W as in our example:"
    ]
   },
   {

--- a/docs/notebooks/plotting.ipynb
+++ b/docs/notebooks/plotting.ipynb
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To achieve this, you need to explicitely create the axes: "
+    "To achieve this, you need to explicitly create the axes: "
    ]
   },
   {

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -89,7 +89,7 @@ New regions
 Bug Fixes
 ~~~~~~~~~
 
-- The name of lon and lat coordinates when passed as single elements is now repected when
+- The name of lon and lat coordinates when passed as single elements is now respected when
   creating masks i.e. for ``region.mask(ds.longitude, ds.longitude)`` (:issue:`129`,
   :pull:`294`).
 - Ensure :py:meth:`Regions.plot` uses the current axes (``plt.gca()``) if possible and
@@ -99,7 +99,7 @@ Bug Fixes
 Docs
 ~~~~
 
-- Went over the documentation, imporved some sections, unpinned some packages, modernized
+- Went over the documentation, improved some sections, unpinned some packages, modernized
   some aspects (:pull:`313`).
 
 Internal Changes
@@ -131,7 +131,7 @@ Breaking Changes
   details (:issue:`151`).
 - Updates to :py:meth:`Regions.plot` and :py:meth:`Regions.plot_regions` (:pull:`246`):
 
-  - Deprecated all positional arguments (keword arguments only).
+  - Deprecated all positional arguments (keyword arguments only).
   - The ``regions`` keyword was deprecated. Subset regions before plotting, i.e.
     use ``r[regions].plot()`` instead of ``r.plot(regions=regions)``. This will allow
     to remove a argument from the methods.
@@ -183,10 +183,10 @@ Docs
 - Install `regionmask` via `ci/requirements/docs.yml` on RTD using pip and update the
   packages: don't require jupyter (but ipykernel, which leads to a smaller environment),
   use new versions of sphinx and sphinx_rtd_theme (:pull:`248`).
-- Pin cartopy to version 0.19 and matplotlib to version 3.4 and use a (temorary) fix for
+- Pin cartopy to version 0.19 and matplotlib to version 3.4 and use a (temporary) fix for
   :issue:`165`. This allows to make use of `conda-forge/cartopy-feedstock#116
   <https://github.com/conda-forge/cartopy-feedstock/pull/116>`__ such that natural_earth
-  shapefiles can be donwloaded again. Also added some other minor doc updates
+  shapefiles can be downloaded again. Also added some other minor doc updates
   (:pull:`269`).
 
 Internal Changes

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -28,7 +28,7 @@ Parameters
 {gp_doc}lon_or_obj : object or array_like
     Can either be a longitude array and then ``lat`` needs to be
     given. Or an object where the longitude and latitude can be
-    retrived as: ``lon = lon_or_obj[lon_name]`` and
+    retrieved as: ``lon = lon_or_obj[lon_name]`` and
     ``lat = lon_or_obj[lat_name]``.
 lat : array_like, optional
     If ``lon_or_obj`` is a longitude array, the latitude needs to be
@@ -570,7 +570,7 @@ def _get_LON_LAT_out_shape(lon, lat, fill, is_unstructured=False):
 
 
 def _transform_from_latlon(lon, lat):
-    """perform an affine tranformation to the latitude/longitude coordinates"""
+    """perform an affine transformation to the latitude/longitude coordinates"""
 
     from affine import Affine
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -48,8 +48,8 @@ def _draw_poly(ax, polygons, tolerance=None, **kwargs):
     # from matplotlib.path import Path
     # import matplotlib.patches as patches
     # paths = [Path(coord) for coord in coords]
-    # patchs = [patches.PathPatch(path, facecolor='none', **kwargs) for path in paths]
-    # [ax.add_patch(patch) for patch in patchs]
+    # patches = [patches.PathPatch(path, facecolor='none', **kwargs) for path in paths]
+    # [ax.add_patch(patch) for patch in patches]
     # ax.autoscale_view()
 
 

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -351,7 +351,7 @@ def _fix_ocean_basins_50_cartopy(self, df):
         df = _fix_ocean_basins_50_v5_0_0(self, df)
     else:
         raise ValueError(
-            "Unkown version of the ocean basins 50m data from naturalearth. "
+            "Unknown version of the ocean basins 50m data from naturalearth. "
             f"{ALTERNATIVE}."
         )
 

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -736,7 +736,7 @@ def test_determine_method(lon, m_lon, lat, m_lat):
 # =============================================================================
 # =============================================================================
 
-# ensure a global region incudes all gridpoints - also the ones at
+# ensure a global region includes all gridpoints - also the ones at
 # 0°E/ -180°E and -90°N (#GH159)
 
 outline_GLOB_180 = np.array(

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -185,7 +185,7 @@ def test_plot_projection():
         ax = r1.plot(tolerance=None)
         assert isinstance(ax.projection, ccrs.PlateCarree)
 
-    # make sure the proj keword is respected
+    # make sure the proj keyword is respected
     with figure_context():
         ax = r1.plot(tolerance=None, projection=ccrs.Miller())
         assert isinstance(ax.projection, ccrs.Miller)
@@ -360,7 +360,7 @@ def test_plot_regions_kw_deprecated(plotfunc):
 @requires_cartopy
 def test_error_extra_kwarg():
     # manual TypeError for extra kwargs
-    # remove test after coastlines and proj kewords are removed
+    # remove test after coastlines and proj keywords are removed
 
     with pytest.raises(TypeError, match="got an unexpected keyword argument 'bar'"):
         with figure_context():

--- a/regionmask/tests/test_segmentize.py
+++ b/regionmask/tests/test_segmentize.py
@@ -54,7 +54,7 @@ def test_segmentize():
 
 
 def test_segmentize_mixed_length():
-    # only one of the segements needs to be split
+    # only one of the segments needs to be split
 
     outl = ((0, 0), (0, 1), (0, 5))
     result = segmentize(outl, tolerance=1)

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -164,5 +164,5 @@ def download_naturalearth_region_or_skip(monkeypatch, natural_earth_feature):
         )
     except URLError as e:
         warnings.warn(str(e))
-        warnings.warn("naturalearth donwload timeout - test not run!")
+        warnings.warn("naturalearth download timeout - test not run!")
         pytest.skip()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Fix typos using [codespell](https://github.com/codespell-project/codespell) with the following command:

```bash
codespell --skip=".git,devel" --ignore-words-list "cna,wan,nd" . -w -i 3
```