### PR TITLE
rtd: fix dirty version (using `git update-index --assume-unchanged`)

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -38,4 +38,4 @@ dependencies:
     - intake_geopandas>=0.2.4
     - msgpack
     # install regionmask relative to this file. Needs to be editable to be accepted.
-    - -e ../..
+    # - -e ../.. -> is now done in readthedocs.yml pre_install

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,12 +31,17 @@ Bug Fixes
 Docs
 ~~~~
 
+- The version number should now be displayed correctly again on readthedocs. Formerly
+  regionmask was installed from a dirty git archive, thus setuptools_scm did not
+  report the correct version number (:pull:`348`, see also `readthedocs/readthedocs.org#8201
+  <https://github.com/readthedocs/readthedocs.org/issues/8201>`_).
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
 - Directly create 3D masks, relevant for overlapping regions as part of :issue:`228`:
 
-  - using shapely, pygeos (:pull:`343`), and rasterio (:pull:`345`) 
+  - using shapely, pygeos (:pull:`343`), and rasterio (:pull:`345`)
   - in the function to determine points at *exactly* -180°E (or 0°E) and -90°N (:pull:`341`)
 
 .. _whats-new.0.9.0:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ build:
       - git status
       - echo $CONDA_DEFAULT_ENV
       - pwd
-      - source activate regionmask-docs; pip install -e .
+      - conda activate regionmask-docs; pip install -e .
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,7 @@ build:
   jobs:
     pre_install:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
-      - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.
+      - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
       - git status
   tools:
     python: mambaforge-4.10

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,8 @@ build:
       - echo $CONDA_DEFAULT_ENV
       - pwd
       - conda init
-      - . activate regionmask-docs; pip install -e .
+      - which pip
+      - pip install -e .
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,10 @@
 version: 2
 build:
   os: ubuntu-20.04
+  jobs:
+    pre_install:
+        # see https://github.com/readthedocs/readthedocs.org/issues/8201
+      - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,8 @@ build:
   jobs:
     pre_install:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
-      - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
+      - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.
+      - git status
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,6 +6,9 @@ build:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
       - git status
+      - echo $CONDA_DEFAULT_ENV
+      - pwd
+      - source activate regionmask-docs; pip install -e .
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,7 +9,7 @@ build:
       - echo $CONDA_DEFAULT_ENV
       - pwd
       - conda init
-      - conda activate regionmask-docs; pip install -e .
+      - . activate regionmask-docs; pip install -e .
   tools:
     python: mambaforge-4.10
 sphinx:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,6 +8,7 @@ build:
       - git status
       - echo $CONDA_DEFAULT_ENV
       - pwd
+      - conda init
       - conda activate regionmask-docs; pip install -e .
   tools:
     python: mambaforge-4.10

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,11 +5,7 @@ build:
     pre_install:
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
-      - git status
-      - echo $CONDA_DEFAULT_ENV
-      - pwd
-      - conda init
-      - which pip
+      # install regionmask, needs to be editable
       - pip install -e .
   tools:
     python: mambaforge-4.10

--- a/regionmask/__init__.py
+++ b/regionmask/__init__.py
@@ -15,8 +15,3 @@ except Exception:
     # Local copy or not installed with setuptools.
     # Disable minimum version checks on downstream libraries.
     __version__ = "999"
-
-# hack for https://github.com/readthedocs/readthedocs.org/issues/8201
-# rtd creates a 'dirty' repo even for tags
-if os.environ.get("READTHEDOCS", None) == "True":
-    __version__ == __version__.split(".dev0+")[0]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

rtd updates some files which messes up the version number when using :

```
import regionmask
regionmask.__version__

'0.9.0.post1.dev0+g4000597.d20220302'
```

(should be `0.9.0`). This tries the workaround suggested in https://github.com/readthedocs/readthedocs.org/issues/8201#issuecomment-1088728000

