### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates once a week
+      interval: 'weekly'


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Adds dependabot config. Should update the tools used for the github actions weekly.