### PR TITLE
fix ocean_basins_50 for ne 5.1.2 (cartopy only)

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,7 @@ build:
   jobs:
     pre_install:
       - which conda
-      - which source
+      - which activate
       - source activate
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,9 +3,6 @@ build:
   os: ubuntu-20.04
   jobs:
     pre_install:
-      - which conda
-      - which activate
-      - source activate
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
       # install regionmask, needs to be editable

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,6 +3,9 @@ build:
   os: ubuntu-20.04
   jobs:
     pre_install:
+      - which conda
+      - which source
+      - source activate
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
       # install regionmask, needs to be editable


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Fixes failed tests for natural earth ocean basins 50 v5.1.2. This only applies to the cartopy download (which is being deprecated), but cannot yet be removed. I might want to add `natural_earth_v5_1_2` at some point...

 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
