### PR TITLE
warn for radian units

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -19,6 +19,9 @@ Breaking Changes
 Enhancements
 ~~~~~~~~~~~~
 
+- The masking functions (e.g. :py:meth:`Regions.mask`) now warn if the `units` of the
+  coordinates(``lat.attrs["units"]`` ) are given as "radians" (:issue:`279`).
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -145,9 +145,16 @@ def _mask(
     # have to do this before np.asarray
     is_unstructured = False
     if isinstance(lon, xr.DataArray) and isinstance(lat, xr.DataArray):
-        if len(lon.dims) == 1 and len(lat.dims) == 1:
+        if lon.ndim == 1 and lat.ndim == 1:
             if lon.name != lon.dims[0] and lat.name != lat.dims[0]:
                 is_unstructured = True
+
+        has_radians = any(c.attrs.get("units") == "radian" for c in (lon, lat))
+        if has_radians and wrap_lon is not False:
+            warnings.warn(
+                "lon or lat is given as 'radian' (see the 'units' attrs). Should they "
+                "be converted to degree?"
+            )
 
     lon = np.asarray(lon)
     lat = np.asarray(lat)

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -18,7 +18,7 @@ from regionmask.core.mask import (
 )
 from regionmask.core.utils import _wrapAngle, create_lon_lat_dataarray_from_bounds
 
-from . import has_pygeos, requires_pygeos
+from . import assert_no_warnings, has_pygeos, requires_pygeos
 from .utils import (
     dummy_ds,
     dummy_region,
@@ -495,6 +495,29 @@ def test_mask_3D_obj(lon_name, lat_name, drop, method):
     )
 
     xr.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("meth", ["mask", "mask_3D"])
+def test_mask_warn_radian(meth):
+
+    lon = dummy_ds.lon.copy()
+    lat = dummy_ds.lat.copy()
+    mask_func = getattr(dummy_region, meth)
+
+    with assert_no_warnings():
+        mask_func(lon, lat)
+
+    lon.attrs["units"] = "radian"
+    with pytest.warns(UserWarning, match="given as 'radian'"):
+        mask_func(lon, lat)
+
+    lat.attrs["units"] = "radian"
+    with pytest.warns(UserWarning, match="given as 'radian'"):
+        mask_func(lon, lat)
+
+    # no warnings with 'wrap_lon=False'
+    with assert_no_warnings():
+        mask_func(lon, lat, wrap_lon=False)
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #279
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

This warns if it detects `lon.attrs["units"] == "radians"`.

@aaronspring - do you want to take a look? Would you like to have a function to do the conversion? Or would this rather belong to another package?