### PR TITLE
make more arguments keyword only

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -16,6 +16,9 @@ v0.10.0 (unreleased)
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
+- Made more arguments keyword-only for several functions and methods, e.g., for
+  :py:meth:`Regions.mask`  (:pull:`368`).
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/licences/SCIKIT_LEARN_LICENSE
+++ b/licences/SCIKIT_LEARN_LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2007-2021 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/regionmask/core/_deprecate.py
+++ b/regionmask/core/_deprecate.py
@@ -1,5 +1,5 @@
 # Adapted from scikit-learn https://github.com/scikit-learn/scikit-learn/pull/13311
-# For reference, here is a copy of the pandas copyright notice:
+# For reference, here is a copy of their copyright notice:
 
 # BSD 3-Clause License
 

--- a/regionmask/core/_deprecate.py
+++ b/regionmask/core/_deprecate.py
@@ -1,0 +1,89 @@
+# Adapted from scikit-learn https://github.com/scikit-learn/scikit-learn/pull/13311
+# For reference, here is a copy of the pandas copyright notice:
+
+# BSD 3-Clause License
+
+# Copyright (c) 2007-2021 The scikit-learn developers.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import inspect
+import warnings
+from functools import wraps
+
+POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
+KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
+POSITIONAL_ONLY = inspect.Parameter.POSITIONAL_ONLY
+
+
+def _deprecate_positional_args(version):
+    """Decorator for methods that issues warnings for positional arguments
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    ``*`` will issue a warning when passed as a positional argument.
+
+    Parameters
+    ----------
+    version : str
+        version of the library when the positional arguments were deprecated
+    """
+
+    def _decorator(f):
+
+        signature = inspect.signature(f)
+
+        pos_or_kw_args = []
+        kwonly_args = []
+        for name, param in signature.parameters.items():
+            if param.kind == POSITIONAL_OR_KEYWORD:
+                pos_or_kw_args.append(name)
+            elif param.kind == KEYWORD_ONLY:
+                kwonly_args.append(name)
+            elif param.kind == POSITIONAL_ONLY:
+                raise TypeError("Cannot handle positional-only params")
+                # because all args are coverted to kwargs below
+
+        @wraps(f)
+        def inner(*args, **kwargs):
+            n_extra_args = len(args) - len(pos_or_kw_args)
+            if n_extra_args > 0:
+
+                extra_args = ", ".join(kwonly_args[:n_extra_args])
+
+                warnings.warn(
+                    f"Passing '{extra_args}' as positional argument(s) "
+                    f"was deprecated in version {version} and will raise an error two "
+                    "releases later. Please pass them as keyword arguments."
+                    "",
+                    FutureWarning,
+                )
+
+            kwargs.update({name: arg for name, arg in zip(pos_or_kw_args, args)})
+            return f(**kwargs)
+
+        return inner
+
+    return _decorator

--- a/regionmask/core/_geopandas.py
+++ b/regionmask/core/_geopandas.py
@@ -3,9 +3,9 @@ import warnings
 import numpy as np
 
 from ..defined_regions._natural_earth import _maybe_get_column
+from ._deprecate import _deprecate_positional_args
 from .mask import _inject_mask_docstring, _mask_2D, _mask_3D
 from .regions import Regions
-from ._deprecate import _deprecate_positional_args
 
 
 def _check_duplicates(data, name):
@@ -243,6 +243,7 @@ def mask_geopandas(
 
 
 mask_geopandas.__doc__ = _inject_mask_docstring(is_3D=False, gp_method=True)
+
 
 @_deprecate_positional_args("0.10.0")
 def mask_3D_geopandas(

--- a/regionmask/core/_geopandas.py
+++ b/regionmask/core/_geopandas.py
@@ -5,6 +5,7 @@ import numpy as np
 from ..defined_regions._natural_earth import _maybe_get_column
 from .mask import _inject_mask_docstring, _mask_2D, _mask_3D
 from .regions import Regions
+from ._deprecate import _deprecate_positional_args
 
 
 def _check_duplicates(data, name):
@@ -58,8 +59,10 @@ def _construct_abbrevs(geodataframe, names):
     return abbrevs
 
 
+@_deprecate_positional_args("0.10.0")
 def from_geopandas(
     geodataframe,
+    *,
     numbers=None,
     names=None,
     abbrevs=None,
@@ -209,10 +212,12 @@ def _prepare_gdf_for_mask(geodataframe, method, numbers):
     return polygons, lon_bounds, numbers
 
 
+@_deprecate_positional_args("0.10.0")
 def mask_geopandas(
     geodataframe,
     lon_or_obj,
     lat=None,
+    *,
     lon_name="lon",
     lat_name="lat",
     numbers=None,
@@ -239,11 +244,12 @@ def mask_geopandas(
 
 mask_geopandas.__doc__ = _inject_mask_docstring(is_3D=False, gp_method=True)
 
-
+@_deprecate_positional_args("0.10.0")
 def mask_3D_geopandas(
     geodataframe,
     lon_or_obj,
     lat=None,
+    *,
     drop=True,
     lon_name="lon",
     lat_name="lat",

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -2,7 +2,8 @@ import warnings
 
 import numpy as np
 
-from .utils import _deprecate_positional, _flatten_polygons
+from ._deprecate import _deprecate_positional_args
+from .utils import _flatten_polygons
 
 
 def _polygons_coords(polygons):
@@ -116,9 +117,10 @@ def _maybe_gca(**kwargs):
     return plt.axes(**kwargs)
 
 
-@_deprecate_positional
+@_deprecate_positional_args("0.8.0")
 def _plot(
     self,
+    *,
     ax=None,
     projection=None,
     regions=None,
@@ -315,9 +317,10 @@ def _plot(
     return ax
 
 
-@_deprecate_positional
+@_deprecate_positional_args("0.8.0")
 def _plot_regions(
     self,
+    *,
     ax=None,
     regions=None,
     add_label=True,

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from shapely.geometry import MultiPolygon, Polygon
 
+from ._deprecate import _deprecate_positional_args
 from .formatting import _display
 from .mask import _inject_mask_docstring, _mask_2D, _mask_3D
 from .plot import _plot, _plot_regions
@@ -279,10 +280,12 @@ class Regions:
         """
         return _display(self, max_rows, max_width, max_colwidth)
 
+    @_deprecate_positional_args("0.10.0")
     def mask(
         self,
         lon_or_obj,
         lat=None,
+        *,
         lon_name="lon",
         lat_name="lat",
         method=None,
@@ -309,10 +312,12 @@ class Regions:
 
     mask.__doc__ = _inject_mask_docstring(is_3D=False, gp_method=False)
 
+    @_deprecate_positional_args("0.10.0")
     def mask_3D(
         self,
         lon_or_obj,
         lat=None,
+        *,
         drop=True,
         lon_name="lon",
         lat_name="lat",

--- a/regionmask/core/utils.py
+++ b/regionmask/core/utils.py
@@ -1,6 +1,3 @@
-import warnings
-from functools import wraps
-
 import numpy as np
 import xarray as xr
 
@@ -210,27 +207,6 @@ def _find_splitpoint(lon):
         raise ValueError("more or less than one split point found")
 
     return split_point.squeeze() + 1
-
-
-def _deprecate_positional(func):
-    """deprecate all positional arguments (except self)"""
-
-    @wraps(func)
-    def _inner(*args, **kwargs):
-
-        name = func.__name__
-
-        # careful only use for class methods
-        if len(args) > 1:
-            warnings.warn(
-                f"'{name}' now requires keyword arguments. From v0.10.0 "
-                "passing positional arguments will result in an error",
-                FutureWarning,
-            )
-
-        return func(*args, **kwargs)
-
-    return _inner
 
 
 def unpackbits(numbers, num_bits):

--- a/regionmask/tests/test_deprecate.py
+++ b/regionmask/tests/test_deprecate.py
@@ -1,0 +1,80 @@
+import pytest
+
+from regionmask.core._deprecate import _deprecate_positional_args
+
+
+def test_deprecate_positional_args_warns_for_function():
+    @_deprecate_positional_args("v0.1")
+    def f1(a, b, *, c=1, d=1):
+        pass
+
+    with pytest.warns(FutureWarning, match=r".*v0.1"):
+        f1(1, 2, 3)
+
+    with pytest.warns(FutureWarning, match=r"Passing 'c' as positional"):
+        f1(1, 2, 3)
+
+    with pytest.warns(FutureWarning, match=r"Passing 'c, d' as positional"):
+        f1(1, 2, 3, 4)
+
+    @_deprecate_positional_args("v0.1")
+    def f2(a=1, *, b=1, c=1, d=1):
+        pass
+
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        f2(1, 2)
+
+    @_deprecate_positional_args("v0.1")
+    def f3(a, *, b=1, **kwargs):
+        pass
+
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        f3(1, 2)
+
+    with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+
+        @_deprecate_positional_args("v0.1")
+        def f4(a, /, *, b=2, **kwargs):
+            pass
+
+
+def test_deprecate_positional_args_warns_for_class():
+    class A1:
+        @_deprecate_positional_args("v0.1")
+        def __init__(self, a, b, *, c=1, d=1):
+            pass
+
+    with pytest.warns(FutureWarning, match=r".*v0.1"):
+        A1(1, 2, 3)
+
+    with pytest.warns(FutureWarning, match=r"Passing 'c' as positional"):
+        A1(1, 2, 3)
+
+    with pytest.warns(FutureWarning, match=r"Passing 'c, d' as positional"):
+        A1(1, 2, 3, 4)
+
+    class A2:
+        @_deprecate_positional_args("v0.1")
+        def __init__(self, a=1, b=1, *, c=1, d=1):
+            pass
+
+    with pytest.warns(FutureWarning, match=r"Passing 'c' as positional"):
+        A2(1, 2, 3)
+
+    with pytest.warns(FutureWarning, match=r"Passing 'c, d' as positional"):
+        A2(1, 2, 3, 4)
+
+    class A3:
+        @_deprecate_positional_args("v0.1")
+        def __init__(self, a, *, b=1, **kwargs):
+            pass
+
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        A3(1, 2)
+
+    with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+
+        class A3:
+            @_deprecate_positional_args("v0.1")
+            def __init__(self, a, /, *, b=1, **kwargs):
+                pass

--- a/regionmask/tests/test_deprecate.py
+++ b/regionmask/tests/test_deprecate.py
@@ -32,14 +32,13 @@ def test_deprecate_positional_args_warns_for_function():
         f3(1, 2)
 
     # positional-only arguments not valid in python 3.7
-    try:
-        with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
 
-            @_deprecate_positional_args("v0.1")
-            def f4(a, /, *, b=2, **kwargs):
-                pass
-    except SyntaxError:
-        pass
+    # with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+
+    #     @_deprecate_positional_args("v0.1")
+    #     def f4(a, /, *, b=2, **kwargs):
+    #         pass
+
 
 def test_deprecate_positional_args_warns_for_class():
     class A1:
@@ -76,12 +75,9 @@ def test_deprecate_positional_args_warns_for_class():
         A3(1, 2)
 
     # positional-only arguments not valid in python 3.7
-    try:
-        with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+    # with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
 
-            class A3:
-                @_deprecate_positional_args("v0.1")
-                def __init__(self, a, /, *, b=1, **kwargs):
-                    pass
-    except SyntaxError:
-        pass
+    #     class A3:
+    #         @_deprecate_positional_args("v0.1")
+    #         def __init__(self, a, /, *, b=1, **kwargs):
+    #             pass

--- a/regionmask/tests/test_deprecate.py
+++ b/regionmask/tests/test_deprecate.py
@@ -31,12 +31,15 @@ def test_deprecate_positional_args_warns_for_function():
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
         f3(1, 2)
 
-    with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+    # positional-only arguments not valid in python 3.7
+    try:
+        with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
 
-        @_deprecate_positional_args("v0.1")
-        def f4(a, /, *, b=2, **kwargs):
-            pass
-
+            @_deprecate_positional_args("v0.1")
+            def f4(a, /, *, b=2, **kwargs):
+                pass
+    except SyntaxError:
+        pass
 
 def test_deprecate_positional_args_warns_for_class():
     class A1:
@@ -72,9 +75,13 @@ def test_deprecate_positional_args_warns_for_class():
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
         A3(1, 2)
 
-    with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+    # positional-only arguments not valid in python 3.7
+    try:
+        with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
 
-        class A3:
-            @_deprecate_positional_args("v0.1")
-            def __init__(self, a, /, *, b=1, **kwargs):
-                pass
+            class A3:
+                @_deprecate_positional_args("v0.1")
+                def __init__(self, a, /, *, b=1, **kwargs):
+                    pass
+    except SyntaxError:
+        pass

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -84,8 +84,8 @@ def figure_context(*args, **kwargs):
 
 
 PLOTFUNCS = [
-    pytest.param("plot", marks=requires_cartopy),
     "plot_regions",
+    pytest.param("plot", marks=requires_cartopy),
 ]
 
 
@@ -376,9 +376,7 @@ def test_plot_deprecate_args(plotfunc):
 
     func = getattr(r1, plotfunc)
 
-    with pytest.warns(
-        FutureWarning, match=f"'_{plotfunc}' now requires keyword arguments"
-    ):
+    with pytest.warns(FutureWarning, match="Passing 'ax' as positional"):
         with figure_context():
             func(None)
 

--- a/regionmask/tests/test_utils.py
+++ b/regionmask/tests/test_utils.py
@@ -3,7 +3,6 @@ import pytest
 
 from regionmask.core.utils import (
     _create_dict_of_numbered_string,
-    _deprecate_positional,
     _equally_spaced_on_split_lon,
     _find_splitpoint,
     _is_180,
@@ -201,18 +200,6 @@ def test_find_splitpoint():
 
     with pytest.raises(ValueError, match="more or less than one split point found"):
         _find_splitpoint([0, 1, 3, 4, 6, 7])
-
-
-def test_deprecate_positional():
-    @_deprecate_positional
-    def func(self, a=1, b=2):
-        pass
-
-    with pytest.warns(FutureWarning, match="'func' now requires keyword arguments"):
-        func(1, 2, 3)
-
-    with pytest.warns(FutureWarning, match="'func' now requires keyword arguments"):
-        func(1, 2, b=3)
 
 
 def test_unpackbits():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This adds a helper to deprecate any number of positional arguments and deprecates some in for `mask` methods.

 - [x] Towards #293 and #364
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
