### PR TITLE
use importlib.metadata if available

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -49,6 +49,8 @@ Internal Changes
 
   - using shapely, pygeos (:pull:`343`), and rasterio (:pull:`345`)
   - in the function to determine points at *exactly* -180°E (or 0°E) and -90°N (:pull:`341`)
+- Use importlib.metadata if available (i.e. for python > 3.7) - should lead to a faster
+  import time for regionmask (:pull:`369`).
 
 .. _whats-new.0.9.0:
 

--- a/regionmask/__init__.py
+++ b/regionmask/__init__.py
@@ -1,16 +1,19 @@
 # flake8: noqa
 
-import os
-
-import pkg_resources
-
 from . import core, defined_regions
 from .core._geopandas import from_geopandas, mask_3D_geopandas, mask_geopandas
 from .core.plot import plot_3D_mask
 from .core.regions import Regions, _OneRegion
 
 try:
-    __version__ = pkg_resources.get_distribution("regionmask").version
+    from importlib.metadata import version as _get_version
+except ImportError:
+    # importlib.metadata not available in python 3.7
+    import pkg_resources
+    _get_version = lambda pkg: pkg_resources.get_distribution(pkg).version
+
+try:
+    __version__ = _get_version("regionmask")
 except Exception:
     # Local copy or not installed with setuptools.
     # Disable minimum version checks on downstream libraries.

--- a/regionmask/__init__.py
+++ b/regionmask/__init__.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     # importlib.metadata not available in python 3.7
     import pkg_resources
+
     _get_version = lambda pkg: pkg_resources.get_distribution(pkg).version
 
 try:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Implements #327 - for python > 3.7
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
