### PR TITLE
version_scheme: no-guess-dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup(use_scm_version={"fallback_version": "999"})
+setup(use_scm_version={"fallback_version": "999", "version_scheme": "no-guess-dev"})


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Add `"version_scheme": "no-guess-dev"` to setup.py - so it's really picked up. Not sure why this is actually relevant when we have pyproject.toml file.
