### PR TITLE
better error when passing single region

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,7 @@ Enhancements
   regions (:pull:`361`, :issue:`346`).
 - The masking functions (e.g. :py:meth:`Regions.mask`) now warn if the `units` of the
   coordinates(``lat.attrs["units"]`` ) are given as "radians" (:issue:`279`).
+- Better error when passing a single region without wrapping it into a list or tuple (:issue:`372`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -91,6 +91,12 @@ class Regions:
         overlap=False,
     ):
 
+        if isinstance(outlines, (np.ndarray, Polygon, MultiPolygon)):
+            klass = type(outlines).__name__
+            raise ValueError(
+                f"Cannot pass a single {klass} as region - please pass it as a list."
+            )
+
         if numbers is None:
             numbers = range(len(outlines))
 
@@ -548,12 +554,15 @@ class _OneRegion:
             outline = np.asarray(outline)
 
             if outline.ndim != 2:
-                raise ValueError("Outline must be 2D")
+                raise ValueError(
+                    "Outline must be 2D. Did you pass a single region and need to wrap "
+                    "it in a list?"
+                )
 
             if outline.shape[1] != 2:
                 raise ValueError("Outline must have Nx2 elements")
 
-            self._coords = np.array(outline)
+            self._coords = outline
 
     def __repr__(self):
 

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -29,6 +29,7 @@ abbrevs_dict = {1: "uSq1", 2: "uSq2"}
 poly1 = Polygon(outl1)
 poly2 = Polygon(outl2)
 poly = {1: poly1, 2: poly2}
+multipoly = MultiPolygon([poly1, poly2])
 
 test_regions2 = Regions(poly, numbers2, names_dict, abbrevs_dict, name=name)
 
@@ -46,6 +47,13 @@ all_numbers = (numbers1, numbers2, numbers3)
 all_first_numbers = (0, 1, 2)
 
 # =============================================================================
+
+
+def test_regions_single_region():
+
+    for o in [np.array(outl1), poly1, multipoly]:
+        with pytest.raises(ValueError, match="Cannot pass a single"):
+            Regions(o)
 
 
 @pytest.mark.parametrize("test_regions", all_test_regions)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #372
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Adds a error when passing a single region to `regioinmask.Regions` - this only partially works when the coordinates are not given as a numpy array or a shapely (Multi)Polygon. This did error before but the message should be better now...