### PR TITLE
fix _deprecate_positional_args

### DIFF
--- a/regionmask/core/_deprecate.py
+++ b/regionmask/core/_deprecate.py
@@ -38,6 +38,7 @@ from functools import wraps
 POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
 KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
 POSITIONAL_ONLY = inspect.Parameter.POSITIONAL_ONLY
+EMPTY = inspect.Parameter.empty
 
 
 def _deprecate_positional_args(version):
@@ -49,40 +50,61 @@ def _deprecate_positional_args(version):
     ----------
     version : str
         version of the library when the positional arguments were deprecated
+    Examples
+    --------
+    Deprecate passing `b` as positional argument:
+    def func(a, b=1):
+        pass
+    @_deprecate_positional_args("v0.1.0")
+    def func(a, *, b=2):
+        pass
+    func(1, 2)
+    Notes
+    -----
+    This function is adapted from scikit-learn under the terms of its license. See
+    licences/SCIKIT_LEARN_LICENSE
     """
 
-    def _decorator(f):
+    def _decorator(func):
 
-        signature = inspect.signature(f)
+        signature = inspect.signature(func)
 
         pos_or_kw_args = []
         kwonly_args = []
         for name, param in signature.parameters.items():
-            if param.kind == POSITIONAL_OR_KEYWORD:
+            if param.kind in (POSITIONAL_OR_KEYWORD, POSITIONAL_ONLY):
                 pos_or_kw_args.append(name)
             elif param.kind == KEYWORD_ONLY:
                 kwonly_args.append(name)
-            elif param.kind == POSITIONAL_ONLY:
-                raise TypeError("Cannot handle positional-only params")
-                # because all args are coverted to kwargs below
+                if param.default is EMPTY:
+                    # IMHO `def f(a, *, b):` does not make sense -> disallow it
+                    # if removing this constraint -> need to add these to kwargs as well
+                    raise TypeError("Keyword-only param without default disallowed.")
 
-        @wraps(f)
+        @wraps(func)
         def inner(*args, **kwargs):
+
+            name = func.__name__
             n_extra_args = len(args) - len(pos_or_kw_args)
             if n_extra_args > 0:
 
                 extra_args = ", ".join(kwonly_args[:n_extra_args])
 
                 warnings.warn(
-                    f"Passing '{extra_args}' as positional argument(s) "
+                    f"Passing '{extra_args}' as positional argument(s) to {name} "
                     f"was deprecated in version {version} and will raise an error two "
                     "releases later. Please pass them as keyword arguments."
                     "",
                     FutureWarning,
+                    stacklevel=2,
                 )
 
-            kwargs.update({name: arg for name, arg in zip(pos_or_kw_args, args)})
-            return f(**kwargs)
+                zip_args = zip(kwonly_args[:n_extra_args], args[-n_extra_args:])
+                kwargs.update({name: arg for name, arg in zip_args})
+
+                return func(*args[:-n_extra_args], **kwargs)
+
+            return func(*args, **kwargs)
 
         return inner
 

--- a/regionmask/tests/test_deprecate.py
+++ b/regionmask/tests/test_deprecate.py
@@ -56,9 +56,9 @@ def test_deprecate_positional_args_warns_for_function():
     # result = f4(1, b=2, f="f")
     # assert result == (1, 2, {"f": "f"})
 
-    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
-        result = f4(1, 2, f="f")
-    assert result == (1, 2, {"f": "f"})
+    # with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+    #     result = f4(1, 2, f="f")
+    # assert result == (1, 2, {"f": "f"})
 
     with pytest.raises(TypeError, match=r"Keyword-only param without default"):
 
@@ -128,9 +128,9 @@ def test_deprecate_positional_args_warns_for_class():
     # result = A4().method(1, b=2, f="f")
     # assert result == (1, 2, {"f": "f"})
 
-    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
-        result = A4().method(1, 2, f="f")
-    assert result == (1, 2, {"f": "f"})
+    # with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+    #     result = A4().method(1, 2, f="f")
+    # assert result == (1, 2, {"f": "f"})
 
     with pytest.raises(TypeError, match=r"Keyword-only param without default"):
 

--- a/regionmask/tests/test_deprecate.py
+++ b/regionmask/tests/test_deprecate.py
@@ -46,15 +46,15 @@ def test_deprecate_positional_args_warns_for_function():
         result = f3(1, 2, f="f")
     assert result == (1, 2, {"f": "f"})
 
-    @_deprecate_positional_args("v0.1")
-    def f4(a, /, *, b="b", **kwargs):
-        return a, b, kwargs
+    # @_deprecate_positional_args("v0.1")
+    # def f4(a, /, *, b="b", **kwargs):
+    #     return a, b, kwargs
 
-    result = f4(1)
-    assert result == (1, "b", {})
+    # result = f4(1)
+    # assert result == (1, "b", {})
 
-    result = f4(1, b=2, f="f")
-    assert result == (1, 2, {"f": "f"})
+    # result = f4(1, b=2, f="f")
+    # assert result == (1, 2, {"f": "f"})
 
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
         result = f4(1, 2, f="f")
@@ -117,16 +117,16 @@ def test_deprecate_positional_args_warns_for_class():
         result = A3().method(1, 2, f="f")
     assert result == (1, 2, {"f": "f"})
 
-    class A4:
-        @_deprecate_positional_args("v0.1")
-        def method(self, a, /, *, b="b", **kwargs):
-            return a, b, kwargs
+    # class A4:
+    #     @_deprecate_positional_args("v0.1")
+    #     def method(self, a, /, *, b="b", **kwargs):
+    #         return a, b, kwargs
 
-    result = A4().method(1)
-    assert result == (1, "b", {})
+    # result = A4().method(1)
+    # assert result == (1, "b", {})
 
-    result = A4().method(1, b=2, f="f")
-    assert result == (1, 2, {"f": "f"})
+    # result = A4().method(1, b=2, f="f")
+    # assert result == (1, 2, {"f": "f"})
 
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
         result = A4().method(1, 2, f="f")

--- a/regionmask/tests/test_deprecate.py
+++ b/regionmask/tests/test_deprecate.py
@@ -5,79 +5,136 @@ from regionmask.core._deprecate import _deprecate_positional_args
 
 def test_deprecate_positional_args_warns_for_function():
     @_deprecate_positional_args("v0.1")
-    def f1(a, b, *, c=1, d=1):
-        pass
+    def f1(a, b, *, c="c", d="d"):
+        return a, b, c, d
+
+    result = f1(1, 2)
+    assert result == (1, 2, "c", "d")
+
+    result = f1(1, 2, c=3, d=4)
+    assert result == (1, 2, 3, 4)
 
     with pytest.warns(FutureWarning, match=r".*v0.1"):
-        f1(1, 2, 3)
+        result = f1(1, 2, 3)
+    assert result == (1, 2, 3, "d")
 
     with pytest.warns(FutureWarning, match=r"Passing 'c' as positional"):
-        f1(1, 2, 3)
+        result = f1(1, 2, 3)
+    assert result == (1, 2, 3, "d")
 
     with pytest.warns(FutureWarning, match=r"Passing 'c, d' as positional"):
-        f1(1, 2, 3, 4)
+        result = f1(1, 2, 3, 4)
+    assert result == (1, 2, 3, 4)
 
     @_deprecate_positional_args("v0.1")
-    def f2(a=1, *, b=1, c=1, d=1):
-        pass
+    def f2(a="a", *, b="b", c="c", d="d"):
+        return a, b, c, d
 
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
-        f2(1, 2)
+        result = f2(1, 2)
+    assert result == (1, 2, "c", "d")
 
     @_deprecate_positional_args("v0.1")
-    def f3(a, *, b=1, **kwargs):
-        pass
+    def f3(a, *, b="b", **kwargs):
+        return a, b, kwargs
 
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
-        f3(1, 2)
+        result = f3(1, 2)
+    assert result == (1, 2, {})
 
-    # positional-only arguments not valid in python 3.7
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        result = f3(1, 2, f="f")
+    assert result == (1, 2, {"f": "f"})
 
-    # with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+    @_deprecate_positional_args("v0.1")
+    def f4(a, /, *, b="b", **kwargs):
+        return a, b, kwargs
 
-    #     @_deprecate_positional_args("v0.1")
-    #     def f4(a, /, *, b=2, **kwargs):
-    #         pass
+    result = f4(1)
+    assert result == (1, "b", {})
+
+    result = f4(1, b=2, f="f")
+    assert result == (1, 2, {"f": "f"})
+
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        result = f4(1, 2, f="f")
+    assert result == (1, 2, {"f": "f"})
+
+    with pytest.raises(TypeError, match=r"Keyword-only param without default"):
+
+        @_deprecate_positional_args("v0.1")
+        def f5(a, *, b, c=3, **kwargs):
+            pass
 
 
 def test_deprecate_positional_args_warns_for_class():
     class A1:
         @_deprecate_positional_args("v0.1")
-        def __init__(self, a, b, *, c=1, d=1):
-            pass
+        def method(self, a, b, *, c="c", d="d"):
+            return a, b, c, d
+
+    result = A1().method(1, 2)
+    assert result == (1, 2, "c", "d")
+
+    result = A1().method(1, 2, c=3, d=4)
+    assert result == (1, 2, 3, 4)
 
     with pytest.warns(FutureWarning, match=r".*v0.1"):
-        A1(1, 2, 3)
+        result = A1().method(1, 2, 3)
+    assert result == (1, 2, 3, "d")
 
     with pytest.warns(FutureWarning, match=r"Passing 'c' as positional"):
-        A1(1, 2, 3)
+        result = A1().method(1, 2, 3)
+    assert result == (1, 2, 3, "d")
 
     with pytest.warns(FutureWarning, match=r"Passing 'c, d' as positional"):
-        A1(1, 2, 3, 4)
+        result = A1().method(1, 2, 3, 4)
+    assert result == (1, 2, 3, 4)
 
     class A2:
         @_deprecate_positional_args("v0.1")
-        def __init__(self, a=1, b=1, *, c=1, d=1):
-            pass
+        def method(self, a=1, b=1, *, c="c", d="d"):
+            return a, b, c, d
 
     with pytest.warns(FutureWarning, match=r"Passing 'c' as positional"):
-        A2(1, 2, 3)
+        result = A2().method(1, 2, 3)
+    assert result == (1, 2, 3, "d")
 
     with pytest.warns(FutureWarning, match=r"Passing 'c, d' as positional"):
-        A2(1, 2, 3, 4)
+        result = A2().method(1, 2, 3, 4)
+    assert result == (1, 2, 3, 4)
 
     class A3:
         @_deprecate_positional_args("v0.1")
-        def __init__(self, a, *, b=1, **kwargs):
-            pass
+        def method(self, a, *, b="b", **kwargs):
+            return a, b, kwargs
 
     with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
-        A3(1, 2)
+        result = A3().method(1, 2)
+    assert result == (1, 2, {})
 
-    # positional-only arguments not valid in python 3.7
-    # with pytest.raises(TypeError, match=r"Cannot handle positional-only params"):
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        result = A3().method(1, 2, f="f")
+    assert result == (1, 2, {"f": "f"})
 
-    #     class A3:
-    #         @_deprecate_positional_args("v0.1")
-    #         def __init__(self, a, /, *, b=1, **kwargs):
-    #             pass
+    class A4:
+        @_deprecate_positional_args("v0.1")
+        def method(self, a, /, *, b="b", **kwargs):
+            return a, b, kwargs
+
+    result = A4().method(1)
+    assert result == (1, "b", {})
+
+    result = A4().method(1, b=2, f="f")
+    assert result == (1, 2, {"f": "f"})
+
+    with pytest.warns(FutureWarning, match=r"Passing 'b' as positional"):
+        result = A4().method(1, 2, f="f")
+    assert result == (1, 2, {"f": "f"})
+
+    with pytest.raises(TypeError, match=r"Keyword-only param without default"):
+
+        class A5:
+            @_deprecate_positional_args("v0.1")
+            def __init__(self, a, *, b, c=3, **kwargs):
+                pass


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Ensure params are passed on correctly in `_deprecate_positional_args` - see also pydata/xarray#6967
