### PR TITLE
tweak Regions.__repr__

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -60,6 +60,7 @@ Internal Changes
   - in the function to determine points at *exactly* -180°E (or 0°E) and -90°N (:pull:`341`)
 - Use importlib.metadata if available (i.e. for python > 3.7) - should lead to a faster
   import time for regionmask (:pull:`369`).
+- Small changes to the repr of :py:class:`Regions`  (:pull:`378`).
 
 .. _whats-new.0.9.0:
 

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -284,7 +284,7 @@ class Regions:
         Used as the repr.
 
         """
-        return _display(self, max_rows, max_width, max_colwidth)
+        return _display(self, max_rows, max_width)
 
     @_deprecate_positional_args("0.10.0")
     def mask(

--- a/regionmask/tests/test_formatting.py
+++ b/regionmask/tests/test_formatting.py
@@ -4,16 +4,12 @@ from regionmask.core import formatting
 from regionmask.defined_regions import srex
 
 
-def test_pretty_print():
-    assert formatting.pretty_print("abcdefghij", 8) == "abcde..."
-    assert formatting.pretty_print("ß", 1) == "ß"
-    assert formatting.pretty_print("x", 3) == "x  "
-    assert formatting.pretty_print("x", 3, False) == "  x"
-
-
 def test_maybe_truncate():
     assert formatting.maybe_truncate("ß", 10) == "ß"
     assert formatting.maybe_truncate("abcdefghij", 8) == "abcde..."
+
+    for max_length in range(-1, 4):
+        assert formatting.maybe_truncate("abcdefghij", max_length) == "..."
 
 
 def test_repr_srex():
@@ -22,8 +18,7 @@ def test_repr_srex():
 
     result = srex.__repr__()
 
-    expected = """<regionmask.Regions>
-Name:     SREX
+    expected = """<regionmask.Regions 'SREX'>
 Source:   Seneviratne et al., 2012 (https://www.ipcc.ch/site/assets/uploads/2...
 overlap:  False
 
@@ -47,14 +42,14 @@ Regions:
 
 def test_display_metadata():
 
-    expected = ["Name:     name", "overlap:  False"]
-    result = formatting._display_metadata("name", None, False)
+    expected = ["overlap:  False"]
+    result = formatting._display_metadata(None, False)
     assert result == expected
 
-    expected = ["Name:     name", "Source:   source", "overlap:  True"]
-    result = formatting._display_metadata("name", "source", True)
+    expected = ["Source:   source", "overlap:  True"]
+    result = formatting._display_metadata("source", True)
     assert result == expected
 
-    expected = ["Name:     na...", "overlap:  None"]
-    result = formatting._display_metadata("name of regions", None, None, max_width=15)
+    expected = ["Source:   to...", "overlap:  None"]
+    result = formatting._display_metadata("to truncate", None, max_width=15)
     assert result == expected


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #377
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

This does not really close #377 - I could not get the pandas part to work, but the metadata should be truncated a bit more consistently.
