### PR TITLE
deprecate method keyword

### DIFF
--- a/regionmask/core/options.py
+++ b/regionmask/core/options.py
@@ -1,9 +1,7 @@
 # adapted from xarray under the terms of its license - see licences/XARRAY_LICENSE
 
 
-OPTIONS = {
-    "display_max_rows": 10,
-}
+OPTIONS = {"display_max_rows": 10, "backend": None}
 
 
 def _optional_positive_integer(name: str, value: int) -> bool:
@@ -12,8 +10,19 @@ def _optional_positive_integer(name: str, value: int) -> bool:
         raise ValueError(f"'{name}' must be a positive integer or None, got '{value}'")
 
 
+def _validate_backend(name: str, value: str):
+
+    if value == "rasterize":
+        raise ValueError("'rasterize' has been renamed to 'rasterio'.")
+
+    if value not in (None, "rasterio", "shapely", "pygeos"):
+        msg = "'backend' must be None or one of 'rasterio', 'shapely' and 'pygeos'."
+        raise ValueError(msg)
+
+
 _VALIDATORS = {
     "display_max_rows": _optional_positive_integer,
+    "backend": _validate_backend,
 }
 
 
@@ -25,6 +34,12 @@ class set_options:
     ----------
     display_max_rows : int, default: 10
         Maximum display rows.
+    backend : None | "rasterio" | "shapely" | "pygeos", default: None
+        Only for testing purposes. Which backend to use to determine if a grid point
+        belongs to a region. The different backends have the same behaviour but differ
+        in their speed and kind of coordinates the can handle. Regionmask selects the
+        fastest backend available. This options replaces the ``method`` keyword of the
+        ``mask*`` methods.
 
     Examples
     --------

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -755,7 +755,7 @@ def test_rasterize_on_split_lon_asymmetric():
     lat = np.arange(75, 13, -2)
     ds = xr.Dataset(coords=dict(lon=lon, lat=lat))
 
-    assert _determine_method(ds.lon, ds.lat) == "rasterize_flip"
+    assert _determine_method(ds.lon, ds.lat) == "rasterio_flip"
 
     result = r_US_180_cw.mask(ds, method="rasterize")
     expected = r_US_180_cw.mask(ds, method="shapely")
@@ -764,9 +764,9 @@ def test_rasterize_on_split_lon_asymmetric():
 
 METHOD_IRREGULAR = "pygeos" if has_pygeos else "shapely"
 METHODS = {
-    0: "rasterize",
-    1: "rasterize_flip",
-    2: "rasterize_split",
+    0: "rasterio",
+    1: "rasterio_flip",
+    2: "rasterio_split",
     3: METHOD_IRREGULAR,
 }
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #122
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

This

- deprecates the `method` keyword from the `mask*` methods
- adds the `backend` setting in `regionmask.set_options`
- renames `"rasterize"` to `"rasterio"`.

As always I am a bit unsure if this is a good idea. Maybe I am just so used to the way it is done. The reason I want to do is that (i) to hide the keyword (ii) the name `method` is misleading. The good thing is that this should barely affect anyone as there is no reason to set `method="..."` (except for testing and rare cases). So I'll mark this as draft and let it sit for some days to get used to it.
