### PR TITLE
support python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # Bookend python versions
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,6 +32,7 @@ Enhancements
 - Added :py:class:`set_options` to regionmask which can, currently, be used to control
   the number of displayed rows of :py:class:`Regions` (:issue:`#376`).
 - Create faster masks with shapely 2.0, which replaces pygeos (:pull:`#349`).
+- Add python 3.11 to list of supported versions (:pull:`390`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -28,13 +28,13 @@ def _test_region(defined_region):
     assert region.lon_180
 
 
-@pytest.mark.parametrize("defined_region", REGIONS)
+@pytest.mark.parametrize("defined_region", REGIONS, ids=str)
 def test_defined_region(defined_region):
 
     _test_region(defined_region)
 
 
-@pytest.mark.parametrize("defined_region", REGIONS_DEPRECATED)
+@pytest.mark.parametrize("defined_region", REGIONS_DEPRECATED, ids=str)
 def test_defined_region_deprecated(defined_region):
 
     match = "The ``_ar6_pre_revisions`` regions are deprecated"
@@ -44,7 +44,7 @@ def test_defined_region_deprecated(defined_region):
 
 @requires_cartopy
 @pytest.mark.filterwarnings("ignore:Downloading")
-@pytest.mark.parametrize("defined_region", REGIONS_REQUIRING_CARTOPY)
+@pytest.mark.parametrize("defined_region", REGIONS_REQUIRING_CARTOPY, ids=str)
 def test_defined_regions_natural_earth(monkeypatch, defined_region):
     # TODO: remove this test once defined_regions.natural_earth is removed
 
@@ -99,7 +99,7 @@ def test_fix_ocean_basins_50():
 
 
 @requires_cartopy
-def test_natural_earth_loaded_as_utf8(monkeypatch):
+def test_natural_earth_loaded_as_utf8():
     # GH 95
 
     region = defined_regions.natural_earth_v5_0_0.ocean_basins_50

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -8,7 +8,7 @@ from regionmask.defined_regions._natural_earth import _maybe_get_column
 
 from . import has_cartopy, requires_cartopy
 from .utils import (
-    REGIONS,
+    REGIONS_ALL,
     REGIONS_DEPRECATED,
     REGIONS_REQUIRING_CARTOPY,
     download_naturalearth_region_or_skip,
@@ -28,7 +28,7 @@ def _test_region(defined_region):
     assert region.lon_180
 
 
-@pytest.mark.parametrize("defined_region", REGIONS, ids=str)
+@pytest.mark.parametrize("defined_region", REGIONS_ALL, ids=str)
 def test_defined_region(defined_region):
 
     _test_region(defined_region)

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -26,18 +26,22 @@ dummy_ds = xr.Dataset(coords={"lon": _dummy_lon, "lat": _dummy_lat})
 # | b fill |
 
 
-def expected_mask_2D(a=0, b=1, fill=np.NaN, flatten=False, coords=None, dims=None):
+def expected_mask_1D():
+    expected = expected_mask_2D()
+
+    return expected.stack(cells=("lat", "lon")).reset_index("cells")
+
+
+def expected_mask_2D(
+    a=0, b=1, fill=np.NaN, coords=None, lon_name="lon", lat_name="lat"
+):
 
     mask = np.array([[a, fill], [b, fill]])
 
-    if flatten:
-        mask = mask.flatten()
-
     if coords is None:
-        coords = {"lon": _dummy_lon, "lat": _dummy_lat}
+        coords = {lon_name: _dummy_lon, lat_name: _dummy_lat}
 
-    if dims is None:
-        dims = ("lat", "lon")
+    dims = (lat_name, lon_name)
 
     flag_values = np.array([a, b])
     flag_meanings = "r0 r1"
@@ -50,7 +54,7 @@ def expected_mask_2D(a=0, b=1, fill=np.NaN, flatten=False, coords=None, dims=Non
     return xr.DataArray(mask, dims=dims, coords=coords, name="mask", attrs=attrs)
 
 
-def expected_mask_3D(drop, coords=None, overlap=False):
+def expected_mask_3D(drop, coords=None, overlap=False, lon_name="lon", lat_name="lat"):
 
     a = [[True, False], [False, False]]
     b = [[False, False], [True, False]]
@@ -62,7 +66,7 @@ def expected_mask_3D(drop, coords=None, overlap=False):
         mask = np.array([a, b, c])
 
     if coords is None:
-        coords = {"lon": _dummy_lon, "lat": _dummy_lat}
+        coords = {lon_name: _dummy_lon, lat_name: _dummy_lat}
 
     numbers = list(range(4)) if overlap else list(range(3))
 
@@ -73,7 +77,7 @@ def expected_mask_3D(drop, coords=None, overlap=False):
             "names": ("region", [f"Region{i}" for i in numbers]),
         }
     )
-    dims = ("region",) + ("lat", "lon")
+    dims = ("region",) + (lat_name, lon_name)
     attrs = {"standard_name": "region"}
 
     expected = xr.DataArray(mask, coords=coords, dims=dims, name="mask", attrs=attrs)
@@ -102,8 +106,7 @@ REGIONS = [
     DefinedRegion("srex", 26),
 ]
 
-_REGIONS_NATURAL_EARTH = [
-    # v4.1.0
+_REGIONS_NATURAL_EARTH_v4_1_0 = [
     DefinedRegion("natural_earth_v4_1_0.countries_110", 177),
     DefinedRegion("natural_earth_v4_1_0.countries_50", 241),
     DefinedRegion("natural_earth_v4_1_0.us_states_50", 51),
@@ -112,7 +115,9 @@ _REGIONS_NATURAL_EARTH = [
     DefinedRegion("natural_earth_v4_1_0.land_50", 1),
     DefinedRegion("natural_earth_v4_1_0.land_10", 1),
     DefinedRegion("natural_earth_v4_1_0.ocean_basins_50", 119),
-    # v5.0.0
+]
+
+_REGIONS_NATURAL_EARTH_v5_0_0 = [
     DefinedRegion("natural_earth_v5_0_0.countries_110", 177),
     DefinedRegion("natural_earth_v5_0_0.countries_50", 242),
     DefinedRegion("natural_earth_v5_0_0.us_states_50", 51),
@@ -123,7 +128,10 @@ _REGIONS_NATURAL_EARTH = [
     DefinedRegion("natural_earth_v5_0_0.ocean_basins_50", 117),
 ]
 
-REGIONS += _REGIONS_NATURAL_EARTH
+REGIONS += _REGIONS_NATURAL_EARTH_v5_0_0
+
+REGIONS_ALL = REGIONS.copy()
+REGIONS_ALL += _REGIONS_NATURAL_EARTH_v4_1_0
 
 
 REGIONS_DEPRECATED = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Atmospheric Science
     Topic :: Scientific/Engineering :: GIS


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Added a CI run for python 3.11 to see if the tests pass and some additional changes to the tests.