### PR TITLE
configurable cache dir

### DIFF
--- a/docs/defined_countries.rst
+++ b/docs/defined_countries.rst
@@ -3,7 +3,7 @@ Countries/ States (NaturalEarth)
 
 The outline of the countries are obtained from
 `Natural Earth <http://www.naturalearthdata.com/>`_.
-They are automatically downloaded, cached and opened with geopandas.
+They are automatically downloaded, cached\ [#]_ and opened with geopandas.
 The following countries and regions are defined in regionmask.
 
 * Countries 1:110m
@@ -71,3 +71,6 @@ Also create a mask for a 1° grid over the US:
     states.plot(add_label=False);
     @savefig plotting_states_mask.png width=100%
     mask.plot(add_colorbar=False)
+
+
+.. [#] You can change the cache location using ``regionmask.set_options(cache_dir="~/.rmask")``.

--- a/docs/defined_landmask.rst
+++ b/docs/defined_landmask.rst
@@ -3,7 +3,7 @@ Landmask (NaturalEarth)
 
 The outline of the landmask is obtained from
 `Natural Earth <http://www.naturalearthdata.com/>`_.
-It is automatically downloaded, cached and opened with geopandas.
+It is automatically downloaded, cached\ [#]_ and opened with geopandas.
 The following landmasks are currently available:
 
 * Land 1:110m
@@ -44,3 +44,5 @@ Landmask
 
     @savefig plotting_landmask.png width=100%
     land.plot(add_label=False)
+
+.. [#] You can change the cache location using ``regionmask.set_options(cache_dir="~/.rmask")``.

--- a/docs/defined_ocean_basins.rst
+++ b/docs/defined_ocean_basins.rst
@@ -3,7 +3,7 @@ Marine Areas/ Ocean Basins (NaturalEarth)
 
 The outline of the marine areas are obtained from
 `Natural Earth <http://www.naturalearthdata.com/>`_.
-They are automatically downloaded, cached and opened with geopandas.
+They are automatically downloaded, cached\ [#]_ and opened with geopandas.
 The following marine regions are defined in regionmask:
 
 * Marine Areas 1:50m
@@ -59,3 +59,5 @@ Also create a mask for a 1° grid globally:
 
     @savefig plotting_basins_mask.png width=100%
     mask.plot(add_colorbar=False);
+
+.. [#] You can change the cache location using ``regionmask.set_options(cache_dir="~/.rmask")``.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,6 +32,9 @@ Enhancements
 - Added :py:class:`set_options` to regionmask which can, currently, be used to control
   the number of displayed rows of :py:class:`Regions` (:issue:`#376`).
 - Create faster masks with shapely 2.0, which replaces pygeos (:pull:`#349`).
+- Allow setting the cache location manually: ``regionmask.set_options(cache_dir="~/.rmask")``.
+  The default location is given by ``pooch.os_cache("regionmask")``, i.e. `~/.cache/regionmask/`
+  on unix-like operating systems (:pull:`403`).
 - Add python 3.11 to list of supported versions (:pull:`390`).
 
 Deprecations

--- a/regionmask/core/options.py
+++ b/regionmask/core/options.py
@@ -3,16 +3,25 @@
 
 OPTIONS = {
     "display_max_rows": 10,
+    "cache_dir": None,
 }
 
 
-def _optional_positive_integer(name: str, value: int) -> bool:
+def _optional_positive_integer(name: str, value) -> bool:
     if not (value is None or isinstance(value, int) and value > 0):
         raise ValueError(f"'{name}' must be a positive integer or None, got '{value}'")
 
 
+def _optional_str_or_path(name: str, value) -> bool:
+    from pathlib import Path
+
+    if not (value is None or isinstance(value, (str, Path))):
+        raise ValueError(f"'{name}' must be a string or pathlib.Path, got '{value}'")
+
+
 _VALIDATORS = {
     "display_max_rows": _optional_positive_integer,
+    "cache_dir": _optional_str_or_path,
 }
 
 
@@ -24,6 +33,9 @@ class set_options:
     ----------
     display_max_rows : int, default: 10
         Maximum display rows.
+    cache_dir : str | pathlib.Path
+        Location of the cache directory. If None uses the default cache location of
+        your operating system. For unix-like this would be '~/.cache/regionmask'.
 
     Examples
     --------

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -11,6 +11,7 @@ from shapely.geometry import MultiPolygon
 
 from ..core.regions import Regions
 from ..core.utils import _flatten_polygons
+from regionmask.defined_regions._ressources import _get_cache_dir
 
 # TODO: remove deprecated (v0.9.0) natural_earth class and instance & clean up
 
@@ -495,9 +496,6 @@ def _get_shapefilename_cartopy(resolution, category, name):
     return cartopy_file
 
 
-CACHE_ROOT = pooch.os_cache("regionmask")
-
-
 @contextmanager
 def set_pooch_log_level():
     logger = pooch.get_logger()
@@ -522,7 +520,7 @@ def _fetch_aws(version, resolution, category, name):
 
     url = f"{base_url}/{aws_version}/{resolution}_{category}/{bname}.zip"
 
-    path = CACHE_ROOT / f"natural_earth/{version}"
+    path = _get_cache_dir() / f"natural_earth/{version}"
 
     if Version(pooch.__version__) < Version("1.4"):
         # extract_dir not available

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -9,9 +9,10 @@ import pooch
 from packaging.version import Version
 from shapely.geometry import MultiPolygon
 
+from regionmask.defined_regions._ressources import _get_cache_dir
+
 from ..core.regions import Regions
 from ..core.utils import _flatten_polygons
-from regionmask.defined_regions._ressources import _get_cache_dir
 
 # TODO: remove deprecated (v0.9.0) natural_earth class and instance & clean up
 

--- a/regionmask/defined_regions/_ressources.py
+++ b/regionmask/defined_regions/_ressources.py
@@ -1,22 +1,30 @@
 import geopandas as gp
 import pooch
+from pathlib import Path
+from regionmask.core.options import OPTIONS
 
-REMOTE_RESSOURCE = pooch.create(
-    # Use the default cache folder for the OS
-    path=pooch.os_cache("regionmask"),
-    # The remote data is on Github
-    base_url="https://github.com/regionmask/regionmask/raw/main/data/",
-    registry={
-        "IPCC-WGI-reference-regions-v4.zip": "c83881a18e74912385ad578282de721cc8e866b62cbbc75446e52e7041c81cff",
-        "IPCC-WGI-reference-regions-v1.zip": "8507cef52057785117cabc83d6e03414b5994745bf7f297c179eb50507f7ee89",
-    },
-)
+
+def _get_cache_dir():
+    cache_dir = OPTIONS.get("cache_dir") or pooch.os_cache("regionmask")
+
+    return Path(cache_dir).expanduser()
 
 
 def fetch_remote_shapefile(name):
     """
     uses pooch to cache files
     """
+
+    REMOTE_RESSOURCE = pooch.create(
+        # Use the default cache folder for the OS
+        path=_get_cache_dir(),
+        # The remote data is on Github
+        base_url="https://github.com/regionmask/regionmask/raw/main/data/",
+        registry={
+            "IPCC-WGI-reference-regions-v4.zip": "c83881a18e74912385ad578282de721cc8e866b62cbbc75446e52e7041c81cff",
+            "IPCC-WGI-reference-regions-v1.zip": "8507cef52057785117cabc83d6e03414b5994745bf7f297c179eb50507f7ee89",
+        },
+    )
 
     # the file will be downloaded automatically the first time this is run.
     return REMOTE_RESSOURCE.fetch(name)

--- a/regionmask/defined_regions/_ressources.py
+++ b/regionmask/defined_regions/_ressources.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import geopandas as gp
 import pooch
-from pathlib import Path
+
 from regionmask.core.options import OPTIONS
 
 

--- a/regionmask/tests/test_options.py
+++ b/regionmask/tests/test_options.py
@@ -1,9 +1,9 @@
-import pytest
 import os
-import regionmask
-
 from pathlib import Path
 
+import pytest
+
+import regionmask
 from regionmask.defined_regions._ressources import _get_cache_dir
 
 

--- a/regionmask/tests/test_options.py
+++ b/regionmask/tests/test_options.py
@@ -1,6 +1,10 @@
 import pytest
-
+import os
 import regionmask
+
+from pathlib import Path
+
+from regionmask.defined_regions._ressources import _get_cache_dir
 
 
 def test_options_display_max_rows_errors():
@@ -28,3 +32,19 @@ def test_options_display_max_rows(n, expected):
         result = len(result.split("\n"))
 
         assert result == expected + 6 + 1
+
+
+def test_get_cache_dir():
+    import pooch
+
+    default_cache_dir = pooch.os_cache("regionmask")
+
+    assert _get_cache_dir() == default_cache_dir
+
+    with regionmask.set_options(cache_dir="~/.rmask"):
+        assert _get_cache_dir() == Path(os.path.expanduser("~/.rmask"))
+
+    with regionmask.set_options(cache_dir="/any/other/location"):
+        assert _get_cache_dir() == Path("/any/other/location")
+
+    assert _get_cache_dir() == default_cache_dir


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #402
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Allow setting the cache folder via `regionmask.set_options(cache_dir="~/.rmask")`