### PR TITLE
read us_states faster using bbox

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -69,8 +69,10 @@ Internal Changes
   - in the function to determine points at *exactly* -180°E (or 0°E) and -90°N (:pull:`341`)
 - Use importlib.metadata if available (i.e. for python > 3.7) - should lead to a faster
   import time for regionmask (:pull:`369`).
-- Small changes to the repr of :py:class:`Regions`  (:pull:`378`).
+- Small changes to the repr of :py:class:`Regions` (:pull:`378`).
 - Reduce the memory requirements of :py:func:`core.utils.unpackbits` (:issue:`379`:).
+- Speed up loading of `us_states_10` and `us_states_50` by defining a `bbox` which only
+  needs to load a subset of the data (:pull:`405`).
 
 .. _whats-new.0.9.0:
 

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -50,6 +50,7 @@ def _obtain_ne(
     query=None,
     combine_coords=False,
     preprocess=None,
+    bbox=None,
 ):
     """
     create Regions object from naturalearth data
@@ -82,12 +83,15 @@ def _obtain_ne(
         MultiPolygon (used to combine all land Polygons). Default: False.
     preprocess : callable, optional
         If provided, call this function on the geodataframe.
+    bbox : tuple | GeoDataFrame or GeoSeries | shapely Geometry, default None
+        Filter features by given bounding box, GeoSeries, GeoDataFrame or a shapely
+        geometry. See ``geopandas.read_file`` for defails.
     """
 
     import geopandas
 
     # read the file with geopandas
-    df = geopandas.read_file(shpfilename, encoding="utf8")
+    df = geopandas.read_file(shpfilename, encoding="utf8", bbox=bbox)
 
     if query is not None:
         df = df.query(query).reset_index(drop=True)
@@ -252,6 +256,7 @@ class NaturalEarth(ABC):
             opt = dict(
                 title="Natural Earth: US States 50m",
                 query="admin == 'United States of America'",
+                bbox=(-180, 18, -45, 72),
             )
 
             self._us_states_50 = self._obtain_ne(_us_states_50, **opt)
@@ -263,6 +268,7 @@ class NaturalEarth(ABC):
             opt = dict(
                 title="Natural Earth: US States 10m",
                 query="admin == 'United States of America'",
+                bbox=(-180, 18, -45, 72),
             )
 
             self._us_states_10 = self._obtain_ne(_us_states_10, **opt)

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -1,6 +1,7 @@
 import os
 from operator import attrgetter
 
+import numpy as np
 import pytest
 
 from regionmask import Regions, defined_regions
@@ -25,6 +26,9 @@ def _test_region(defined_region):
 
     # currently all regions are -180..180
     assert region.lon_180
+
+    if defined_region.bounds is not None:
+        np.testing.assert_allclose(defined_region.bounds, region.bounds_global)
 
 
 @pytest.mark.parametrize("defined_region", REGIONS_ALL, ids=str)

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -1,6 +1,7 @@
 import warnings
 from dataclasses import dataclass
 from functools import partial
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -89,6 +90,7 @@ class DefinedRegion:
     n_regions: int
     overlap: bool = False
     skip_mask_test: bool = False
+    bounds: Optional[list[float]] = None
 
     def __str__(self):
         # used as name (`ids`) for parametrize
@@ -104,12 +106,28 @@ REGIONS = [
     DefinedRegion("srex", 26),
 ]
 
+
+states10_bounds = (
+    -179.1435033839999,
+    18.906117143000074,
+    179.78093509200005,
+    71.41250234600005,
+)
+
+us_states_50_bounds = (
+    -178.19451843993753,
+    18.963909185849403,
+    -66.98702205598455,
+    71.40768682118639,
+)
+
+
 _REGIONS_NATURAL_EARTH_v4_1_0 = [
     DefinedRegion("natural_earth_v4_1_0.countries_110", 177),
     DefinedRegion("natural_earth_v4_1_0.countries_50", 241),
     DefinedRegion("natural_earth_v4_1_0.countries_10", 258),
-    DefinedRegion("natural_earth_v4_1_0.us_states_50", 51),
-    DefinedRegion("natural_earth_v4_1_0.us_states_10", 51),
+    DefinedRegion("natural_earth_v4_1_0.us_states_50", 51, bounds=us_states_50_bounds),
+    DefinedRegion("natural_earth_v4_1_0.us_states_10", 51, bounds=states10_bounds),
     DefinedRegion("natural_earth_v4_1_0.land_110", 1),
     DefinedRegion("natural_earth_v4_1_0.land_50", 1),
     DefinedRegion("natural_earth_v4_1_0.land_10", 1),
@@ -120,8 +138,8 @@ _REGIONS_NATURAL_EARTH_v5_0_0 = [
     DefinedRegion("natural_earth_v5_0_0.countries_110", 177),
     DefinedRegion("natural_earth_v5_0_0.countries_50", 242),
     DefinedRegion("natural_earth_v5_0_0.countries_10", 258, skip_mask_test=True),
-    DefinedRegion("natural_earth_v5_0_0.us_states_50", 51),
-    DefinedRegion("natural_earth_v5_0_0.us_states_10", 51),
+    DefinedRegion("natural_earth_v5_0_0.us_states_50", 51, bounds=us_states_50_bounds),
+    DefinedRegion("natural_earth_v5_0_0.us_states_10", 51, bounds=states10_bounds),
     DefinedRegion("natural_earth_v5_0_0.land_110", 1),
     DefinedRegion("natural_earth_v5_0_0.land_50", 1),
     DefinedRegion("natural_earth_v5_0_0.land_10", 1),

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -1,7 +1,7 @@
 import warnings
 from dataclasses import dataclass
 from functools import partial
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 import pytest
@@ -90,7 +90,7 @@ class DefinedRegion:
     n_regions: int
     overlap: bool = False
     skip_mask_test: bool = False
-    bounds: Optional[list[float]] = None
+    bounds: Optional[List[float]] = None
 
     def __str__(self):
         # used as name (`ids`) for parametrize


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] xref #404
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

using a `bbox` to load `us_states_10` and `us_states_50` speeds it up considerably (15 times) as only a small amount of the data must be loaded.