### PR TITLE
enable pyogrio to read natural earth data

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -26,6 +26,8 @@ jobs:
             python-version: "3.7"
           - env: "min-all-deps"
             python-version: "3.7"
+          - env: "min-all-deps"
+            python-version: "3.8"
           - env: "shapely-2"
             python-version: "3.10"
     steps:

--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -105,4 +105,4 @@ jobs:
 
       - name: minimum versions policy
         run: |
-          python ci/min_deps_check.py ci/requirements/py37-min-all-deps.yml
+          python ci/min_deps_check.py ci/requirements/py37-min-all-deps.yml ci/requirements/py38-min-all-deps.yml

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -200,17 +200,24 @@ def fmt_version(major: int, minor: int, patch: int = None) -> str:
 
 
 def main() -> None:
-    fname = sys.argv[1]
-    rows = [
-        process_pkg(pkg, major, minor, patch)
-        for pkg, major, minor, patch in parse_requirements(fname)
-    ]
+    fnames = sys.argv[1:]
 
-    print("Package           Required             Policy               Status")
-    print("----------------- -------------------- -------------------- ------")
-    fmt = "{:17} {:7} ({:10}) {:7} ({:10}) {}"
-    for row in rows:
-        print(fmt.format(*row))
+    for fname in fnames:
+        print(f"{fname}")
+        print("=" * len(fname))
+
+        rows = [
+            process_pkg(pkg, major, minor, patch)
+            for pkg, major, minor, patch in parse_requirements(fname)
+        ]
+
+        print("Package           Required             Policy               Status")
+        print("----------------- -------------------- -------------------- ------")
+        fmt = "{:17} {:7} ({:10}) {:7} ({:10}) {}"
+        for row in rows:
+            print(fmt.format(*row))
+
+        print()
 
     assert not has_errors
 

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -11,14 +11,15 @@ dependencies:
   - geopandas
   - matplotlib-base
   - numpy
-  - pooch
   - packaging
+  - pooch
   - pygeos
+  - pyogrio
   - rasterio
   - xarray
 # dependencies for the examples
-  - cftime
   - cf_xarray
+  - cftime
   - netcdf4
 # for regionmask intake example
   - aiohttp
@@ -31,8 +32,8 @@ dependencies:
   - numpydoc
   - pillow
   - pip
-  - sphinx_rtd_theme
   - sphinx
+  - sphinx_rtd_theme
 # for regionmask intake example
   - pip:
     - intake_geopandas>=0.2.4

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - packaging
   - pooch
   - pygeos
-  - pyogrio
+  # - pyogrio # not available in py37
   - rasterio
   - setuptools
   - xarray

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - packaging
   - pooch
   - pygeos
+  - pyogrio
   - rasterio
   - setuptools
   - xarray

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -8,10 +8,11 @@ dependencies:
   - geopandas=0.7
   - matplotlib-base=3.2
   - numpy=1.17
-  - pandas=1.2
   - packaging=21.3
+  - pandas=1.2
   - pooch=1.2
   - pygeos=0.9
+  - pyogrio=0.3
   - rasterio=1.1
   - setuptools=40.4
   - shapely=1.7

--- a/ci/requirements/py37-min-all-deps.yml
+++ b/ci/requirements/py37-min-all-deps.yml
@@ -12,7 +12,6 @@ dependencies:
   - pandas=1.2
   - pooch=1.2
   - pygeos=0.9
-  # - pyogrio=0.3 # requires py3.8+
   - rasterio=1.1
   - setuptools=40.4
   - shapely=1.7

--- a/ci/requirements/py38-min-all-deps.yml
+++ b/ci/requirements/py38-min-all-deps.yml
@@ -14,7 +14,6 @@ dependencies:
   - pygeos=0.9
   - pyogrio=0.3 # requires py3.8+
   - rasterio=1.1
-  - setuptools=40.4
   - shapely=1.7
   - xarray=0.15
 # for testing

--- a/ci/requirements/py38-min-all-deps.yml
+++ b/ci/requirements/py38-min-all-deps.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.7
+  - python=3.8
   - cartopy=0.17
   - geopandas=0.7
   - matplotlib-base=3.2
@@ -12,7 +12,7 @@ dependencies:
   - pandas=1.2
   - pooch=1.2
   - pygeos=0.9
-  # - pyogrio=0.3 # requires py3.8+
+  - pyogrio=0.3 # requires py3.8+
   - rasterio=1.1
   - setuptools=40.4
   - shapely=1.7

--- a/ci/requirements/py38-min-all-deps.yml
+++ b/ci/requirements/py38-min-all-deps.yml
@@ -5,7 +5,8 @@ channels:
 dependencies:
   - python=3.8
   - cartopy=0.17
-  - geopandas=0.7
+  # - geopandas=0.7 # not available in py38
+  - geopandas=0.9
   - matplotlib-base=3.2
   - numpy=1.17
   - packaging=21.3

--- a/ci/requirements/py38-min-all-deps.yml
+++ b/ci/requirements/py38-min-all-deps.yml
@@ -4,18 +4,18 @@ channels:
   - nodefaults
 dependencies:
   - python=3.8
-  - cartopy=0.17
-  # - geopandas=0.7 # not available in py38
-  - geopandas=0.9
-  - matplotlib-base=3.2
-  - numpy=1.17
+  - cartopy=0.20
+  - geopandas=0.8
+  - matplotlib-base=3.5
+  - numpy=1.21
   - packaging=21.3
   - pandas=1.2
   - pooch=1.2
-  - pygeos=0.9
-  - pyogrio=0.3 # requires py3.8+
-  - rasterio=1.1
-  - shapely=1.7
+  - pygeos=0.12
+  # pyogrio makes environment solving difficult
+  - pyogrio=0.3
+  - rasterio=1.2
+  - shapely=1.8
   - xarray=0.15
 # for testing
   - pytest

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,6 +30,12 @@ For parsing flag values
   rich comparison of ``mask.cf`` for 2D masks with the abbreviations or names of the
   regions.
 
+For faster loading of shapefiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- `pyogrio <https://pyogrio.readthedocs.io>`__ (0.3 or later) allows faster reading of
+  shapefiles. Currently only used for natural earth data (as the other data is loaded
+  reasonanbly fast with fiona).
 
 For faster masking
 ~~~~~~~~~~~~~~~~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -36,6 +36,8 @@ Enhancements
   The default location is given by ``pooch.os_cache("regionmask")``, i.e. `~/.cache/regionmask/`
   on unix-like operating systems (:pull:`403`).
 - Add python 3.11 to list of supported versions (:pull:`390`).
+- Added `pyogrio <https://pyogrio.readthedocs.io>`__ as optional dependency. Natural earth
+  data shapefiles are now loaded faster, if pyogrio is installed (:pull:`406`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -14,6 +14,13 @@ from regionmask.defined_regions._ressources import _get_cache_dir
 from ..core.regions import Regions
 from ..core.utils import _flatten_polygons
 
+try:
+    import pyogrio  # noqa: F401
+
+    engine = "pyogrio"
+except ImportError:
+    engine = "fiona"
+
 # TODO: remove deprecated (v0.9.0) natural_earth class and instance & clean up
 
 ALTERNATIVE = (
@@ -91,7 +98,7 @@ def _obtain_ne(
     import geopandas
 
     # read the file with geopandas
-    df = geopandas.read_file(shpfilename, encoding="utf8", bbox=bbox)
+    df = geopandas.read_file(shpfilename, encoding="utf8", bbox=bbox, engine=engine)
 
     if query is not None:
         df = df.query(query).reset_index(drop=True)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #404
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

This should speed up the natural earth data shapefiles - even after #405 (which already sped up the tests from 60s to 15s). Not this one should bring it down from 15s to 2s (assuming the data is already downloaded).