### PR TITLE
use mamba-org/setup-micromamba for CI

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -43,13 +43,12 @@ jobs:
             echo "CONDA_ENV_FILE=ci/requirements/py${PY}-${{ matrix.env }}.yml" >> $GITHUB_ENV
 
       - name: Create conda environment
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
           cache-downloads: true
-          cache-downloads-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
-          micromamba-version: 'latest'
+          cache-downloads-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}"
           environment-file: ${{ env.CONDA_ENV_FILE }}
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
 
       - name: Install regionmask
@@ -91,13 +90,12 @@ jobs:
           fetch-depth: 0 # Fetch all history for all branches and tags.
 
       - name: Create conda environment
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: min-version-policy
-          environment-file: false
           micromamba-version: 'latest'
-          extra-specs: |
-            python="3.10"
+          create-args: >-
+            python=3.10
             pyyaml
             conda
             python-dateutil

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,13 +34,12 @@ jobs:
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
 
       - name: Create conda environment
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
           cache-downloads: true
-          cache-downloads-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
-          micromamba-version: 'latest'
+          cache-downloads-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}"
           environment-file: ci/requirements/environment.yml
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
 
       - name: Install regionmask


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

As mamba-org/provision-with-micromamba is being deprecated, switch to mamba-org/setup-micromamba

 - [x] Closes #412
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
