### PR TITLE
remove pygeos from docs & update tests

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -28,7 +28,7 @@ jobs:
             python-version: "3.7"
           - env: "min-all-deps"
             python-version: "3.8"
-          - env: "shapely-2"
+          - env: "shapely_lt_2"
             python-version: "3.10"
     steps:
       - uses: actions/checkout@v3

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -13,7 +13,6 @@ dependencies:
   - numpy
   - packaging
   - pooch
-  - pygeos
   - pyogrio
   - rasterio
   - xarray

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - numpy
   - packaging
   - pooch
-  - pygeos
   # - pyogrio # not available in py37
   - rasterio
   - setuptools

--- a/ci/requirements/py310-shapely_lt_2.yml
+++ b/ci/requirements/py310-shapely_lt_2.yml
@@ -1,6 +1,5 @@
 name: regionmask-tests
 channels:
-  - conda-forge/label/shapely_dev
   - conda-forge
   - nodefaults
 dependencies:
@@ -12,6 +11,7 @@ dependencies:
   - pooch
   - pygeos
   - rasterio
+  - shapely<2
   - setuptools
   - xarray
 # for testing

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,16 +37,6 @@ For faster loading of shapefiles
   shapefiles. Currently only used for natural earth data (as the other data is loaded
   reasonanbly fast with fiona).
 
-For faster masking
-~~~~~~~~~~~~~~~~~~
-
-.. note::
-   pygeos is being deprecated in favour if the upcoming release of shapely 2.0. As soon
-   as shapely 2.0 is released there is no longer an advantage in installing pygeos.
-
-- `pygeos <https://pygeos.readthedocs.io/en/stable/>`__ (0.9 or later) enables faster mask creations for
-  irregular and 2D grids.
-
 Instructions
 ------------
 
@@ -56,7 +46,7 @@ on the conda-forge channel.
 
 .. code-block:: bash
 
-    conda install -c conda-forge regionmask cartopy pygeos
+    conda install -c conda-forge regionmask cartopy
 
 All required dependencies can be installed with pip. You can thus install regionmask
 directly:

--- a/docs/notebooks/method.ipynb
+++ b/docs/notebooks/method.ipynb
@@ -100,13 +100,12 @@
    "source": [
     "## Methods\n",
     "\n",
-    "Regionmask offers three backends (internally called \"methods\"*) to rasterize regions\n",
+    "Regionmask offers two backends (internally called \"methods\"*) to rasterize regions\n",
     "\n",
     "1. `rasterize`: fastest but only for equally-spaced grid, uses `rasterio.features.rasterize` internally.\n",
-    "2. `shapely`: for irregular grids, uses `shapely.vectorized.contains` internally.\n",
-    "3. `pygeos`: a faster alternative for irregular grids. This is method is preferred over (2) if the optional dependency pygeos is installed. Uses `pygeos.STRtree` internally.\n",
+    "2. `shapely`: for irregular grids, uses `shapely.STRtree` internally.\n",
     "\n",
-    "Note: this will change with the upcoming release of shapely 2.0 which will replace pygeos. With shapely 2.0 is is no longer advantageous to install pygeos and shapely 2.0 will also use `shapely.STRtree`.\n",
+    "Note: regionmask offers a third option: `pygeos` (which is faster than shapely < 2.0). However, shapely 2.0 replaces pygeos. With shapely 2.0 is is no longer advantageous to install pygeos.\n",
     "\n",
     "All methods use the `lon` and `lat` coordinates to determine if a grid cell is in a region. `lon` and `lat` are assumed to indicate the *center* of the grid cell. All methods have the same edge behavior and consider 'holes' in the regions. `regionmask` automatically determines which `method` to use.\n",
     "\n",
@@ -135,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "outline = np.array([[-80.0, 50.0], [-80.0, 28.0], [-100.0, 28.0], [-100.0, 50.0]])\n",
+    "outline = np.array([[-80.0, 44.0], [-80.0, 28.0], [-100.0, 28.0], [-100.0, 44.0]])\n",
     "\n",
     "region = regionmask.Regions([outline])"
    ]
@@ -169,8 +168,7 @@
    "outputs": [],
    "source": [
     "mask_rasterize = region.mask(ds_US, method=\"rasterize\")\n",
-    "mask_shapely = region.mask(ds_US, method=\"shapely\")\n",
-    "mask_pygeos = region.mask(ds_US, method=\"pygeos\")"
+    "mask_shapely = region.mask(ds_US, method=\"shapely\")"
    ]
   },
   {
@@ -193,27 +191,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, axes = plt.subplots(1, 3, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
+    "f, axes = plt.subplots(1, 2, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
     "\n",
     "opt = dict(add_colorbar=False, ec=\"0.5\", lw=0.5, transform=ccrs.PlateCarree())\n",
     "\n",
     "mask_rasterize.plot(ax=axes[0], cmap=cmap1, **opt)\n",
     "mask_shapely.plot(ax=axes[1], cmap=cmap2, **opt)\n",
-    "mask_pygeos.plot(ax=axes[2], cmap=cmap3, **opt)\n",
     "\n",
     "\n",
     "for ax in axes:\n",
     "    ax = region.plot_regions(ax=ax, add_label=False)\n",
-    "    ax.set_extent([-105, -75, 25, 55], ccrs.PlateCarree())\n",
+    "    ax.set_extent([-105, -75, 25, 49], ccrs.PlateCarree())\n",
     "    ax.coastlines(lw=0.5)\n",
     "\n",
     "    ax.plot(\n",
     "        ds_US.LON, ds_US.lat, \"*\", color=\"0.5\", ms=0.5, transform=ccrs.PlateCarree()\n",
     "    )\n",
     "\n",
-    "axes[0].set_title(\"rasterize\")\n",
-    "axes[1].set_title(\"shapely\")\n",
-    "axes[2].set_title(\"pygeos\");"
+    "axes[0].set_title(\"backend: rasterize\")\n",
+    "axes[1].set_title(\"backend: shapely\")\n",
+    "None"
    ]
   },
   {
@@ -473,11 +470,10 @@
    "source": [
     "interior = np.array(\n",
     "    [\n",
-    "        [-86.0, 44.0],\n",
-    "        [-86.0, 34.0],\n",
-    "        [-94.0, 34.0],\n",
-    "        [-94.0, 44.0],\n",
-    "        [-86.0, 44.0],\n",
+    "        [-86.0, 40.0],\n",
+    "        [-86.0, 32.0],\n",
+    "        [-94.0, 32.0],\n",
+    "        [-94.0, 40.0],\n",
     "    ]\n",
     ")\n",
     "\n",
@@ -493,8 +489,7 @@
    "outputs": [],
    "source": [
     "mask_hole_rasterize = region_with_hole.mask(ds_US, method=\"rasterize\")\n",
-    "mask_hole_shapely = region_with_hole.mask(ds_US, method=\"shapely\")\n",
-    "mask_hole_pygeos = region_with_hole.mask(ds_US, method=\"pygeos\")"
+    "mask_hole_shapely = region_with_hole.mask(ds_US, method=\"shapely\")"
    ]
   },
   {
@@ -503,27 +498,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, axes = plt.subplots(1, 3, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
+    "f, axes = plt.subplots(1, 2, subplot_kw=dict(projection=ccrs.PlateCarree()))\n",
     "\n",
     "opt = dict(add_colorbar=False, ec=\"0.5\", lw=0.5)\n",
     "\n",
     "mask_hole_rasterize.plot(ax=axes[0], cmap=cmap1, **opt)\n",
     "mask_hole_shapely.plot(ax=axes[1], cmap=cmap2, **opt)\n",
-    "mask_hole_pygeos.plot(ax=axes[2], cmap=cmap3, **opt)\n",
     "\n",
     "for ax in axes:\n",
     "    region_with_hole.plot_regions(ax=ax, add_label=False, line_kws=dict(lw=1))\n",
     "\n",
-    "    ax.set_extent([-105, -75, 25, 55], ccrs.PlateCarree())\n",
+    "    ax.set_extent([-105, -75, 25, 49], ccrs.PlateCarree())\n",
     "    ax.coastlines(lw=0.25)\n",
     "\n",
     "    ax.plot(\n",
     "        ds_US.LON, ds_US.lat, \"o\", color=\"0.5\", ms=0.5, transform=ccrs.PlateCarree()\n",
     "    )\n",
     "\n",
-    "axes[0].set_title(\"rasterize\")\n",
-    "axes[1].set_title(\"shapely\")\n",
-    "axes[2].set_title(\"pygeos\");"
+    "axes[0].set_title(\"backend: rasterize\")\n",
+    "axes[1].set_title(\"backend: shapely\")\n",
+    "None"
    ]
   },
   {
@@ -580,9 +574,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:.conda-regionmask-docs]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-.conda-regionmask-docs-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -594,7 +588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/method.ipynb
+++ b/docs/notebooks/method.ipynb
@@ -60,7 +60,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xarray as xr\n",
     "import numpy as np\n",
     "\n",
     "import cartopy.crs as ccrs\n",
@@ -85,11 +84,9 @@
    "source": [
     "color1 = \"#9ecae1\"\n",
     "color2 = \"#fc9272\"\n",
-    "color3 = \"#cab2d6\"\n",
     "\n",
     "cmap1 = mplc.ListedColormap([color1])\n",
     "cmap2 = mplc.ListedColormap([color2])\n",
-    "cmap3 = mplc.ListedColormap([color3])\n",
     "\n",
     "cmap12 = mplc.ListedColormap([color1, color2])"
    ]
@@ -574,9 +571,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.conda-regionmask-docs]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-.conda-regionmask-docs-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Now that shapely 2 is out and generally supported by geopandas and cartopy (in v0.21.1) we can remove mentioning pygeos from the docs. I plan to support pygeos internally until the minimum required shapely version is 2.0 (but as this is internal-only I might change my mind). 
