### PR TITLE
mark mask method kw as internal

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -50,6 +50,9 @@ Deprecations
 - Passing `lon_name` and `lat_name` to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
   is deprecated. Please pass the lon and lat coordinates direcly, e.g., `mask*(ds[lon_name], ds[lat_name])`
   (:issue:`293` and :pull:`371`).
+- Marked the `method` keyword to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
+  as internal and flagged it for removal in a future version. Passing this argument should only
+  be necessary for testing (:pull:`417`).
 
 New regions
 ~~~~~~~~~~~

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -211,6 +211,15 @@ def _mask(
         msg = "Method must be None or one of 'rasterize', 'shapely' and 'pygeos'."
         raise ValueError(msg)
 
+    if method is not None:
+        warnings.warn(
+            "The ``method`` argument is internal and  will be removed in the future."
+            " Setting the ``method`` (i.e. backend) should not be necessary. Please"
+            " raise an issue if you require it.",
+            FutureWarning,
+            stacklevel=5,
+        )
+
     if method is None:
         method = _determine_method(lon_arr, lat_arr)
     elif method == "shapely" and has_shapely_2:

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -97,6 +97,14 @@ def test_mask(method):
     xr.testing.assert_identical(result, expected)
 
 
+# @pytest.mark.filterwarnings("error:The ``method`` argument is internal")
+@pytest.mark.parametrize("method", MASK_METHODS)
+def test_mask_method_internal(method):
+
+    with pytest.warns(FutureWarning, match="The ``method`` argument is internal"):
+        dummy_region.mask(dummy_ds, method=method)
+
+
 @pytest.mark.skipif(has_pygeos, reason="Only errors if pygeos is missing")
 def test_missing_pygeos_error():
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
 python_files = test_*.py
 testpaths = regionmask/tests
 filterwarnings =
-    ignore:numpy.ufunc size changed, may indicate binary incompatibility.:RuntimeWarning
+    ignore:The ``method`` argument is internal and  will be removed in the future:FutureWarning
 
 [flake8]
 ignore=


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

As I am unsure concerning #385 with #386 as alternative I here add a warning if `method` is set. This should allow to remove it earlier.
