### PR TITLE
rtd: unshallow and allow skip-rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,11 @@ version: 2
 build:
   os: ubuntu-20.04
   jobs:
+    post_checkout:
+      - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183
     pre_install:
+      # unshallow so the version works
+      - git fetch --unshallow
         # see https://github.com/readthedocs/readthedocs.org/issues/8201
       - git update-index --assume-unchanged ci/requirements/docs.yml docs/conf.py
       # install regionmask, needs to be editable


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

And once again rtd needs a fix. Unshallow the git clone so the version works. Also allow adding `[skip-rtd]` in the commit version to skip the build.