### PR TITLE
fix wrap_lon for NaN & simplify

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -46,6 +46,10 @@ New regions
 Bug Fixes
 ~~~~~~~~~
 
+- Fix the wrapping of longitudes that contain ``NA`` values and simplify the ``_wrapAngle``
+  function. Note the wrapping does not dependend on the longitude coordinates since
+  :pull:`271` and thus this bug did not affect users since v0.8.0 (:pull:`425`).
+
 Docs
 ~~~~
 

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -264,10 +264,10 @@ def test_lon_extent():
     outl_ = ((-1, 0), (-1, 1), (360, 1.0), (360, 0))
     test_regions_ = Regions([outl_])
 
-    with pytest.raises(ValueError, match="lon has both data that is larger than 180 "):
+    with pytest.raises(ValueError, match="lon has data that is larger than 180 "):
         test_regions_.lon_180
 
-    with pytest.raises(ValueError, match="lon has both data that is larger than 180 "):
+    with pytest.raises(ValueError, match="lon has data that is larger than 180 "):
         test_regions_.lon_360
 
 

--- a/regionmask/tests/test_utils.py
+++ b/regionmask/tests/test_utils.py
@@ -85,7 +85,7 @@ def test_is_180():
     # allow for small rounding errors
     assert _is_180(-180.0000002, 180.0000002)
 
-    with pytest.raises(ValueError, match="lon has both data that is larger than 180"):
+    with pytest.raises(ValueError, match="lon has data that is larger than 180"):
         _is_180(-1, 181)
 
     with pytest.raises(ValueError, match="and smaller than 0. Additional text."):

--- a/regionmask/tests/test_wrapAngle.py
+++ b/regionmask/tests/test_wrapAngle.py
@@ -93,11 +93,3 @@ def test_wrapAngle_nan(wrap_lon, lon):
     expected = _wrapAngle(lon, wrap_lon=wrap_lon)
 
     np.testing.assert_equal(result, expected)
-
-
-# def test_wrapAngle_nan(lon):
-
-#     result = _wrapAngle(lon + [np.NaN], wrap_lon=True)[:-1]
-#     expected = _wrapAngle(lon, wrap_lon=)
-
-#     np.testing.assert_equal(result, expected)

--- a/regionmask/tests/test_wrapAngle.py
+++ b/regionmask/tests/test_wrapAngle.py
@@ -1,10 +1,10 @@
 import numpy as np
-from pytest import raises
+import pytest
 
 from regionmask.core.utils import _wrapAngle, _wrapAngle180, _wrapAngle360
 
 
-def test__wrapAngle360():
+def test_wrapAngle360():
 
     assert _wrapAngle360(0) == 0
     assert _wrapAngle360(1) == 1
@@ -19,10 +19,10 @@ def test__wrapAngle360():
 
     expected = np.concatenate((np.arange(180, 360), np.arange(0, 180)))
 
-    assert np.allclose(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
-def test__wrapAngle180():
+def test_wrapAngle180():
 
     assert _wrapAngle180(0) == 0
     assert _wrapAngle180(1) == 1
@@ -38,25 +38,41 @@ def test__wrapAngle180():
 
     expected = np.concatenate((np.arange(0, 180), np.arange(-180, 0)))
 
-    assert np.allclose(result, expected)
+    np.testing.assert_allclose(result, expected)
 
 
-def test__wrapAngle():
+@pytest.mark.parametrize("lon", (360, 180, [360], np.array(360), np.array([360])))
+def test_wrapAngle180_not_inplace(lon):
+
+    result = _wrapAngle180(lon)
+    assert lon != result
+
+
+@pytest.mark.parametrize("lon", (360, -10, [360], np.array(360), np.array([360])))
+def test_wrapAngle360_not_inplace(lon):
+
+    result = _wrapAngle360(lon)
+    assert lon != result
+
+
+def test_wrapAngle():
     lon = np.arange(0, 360)
     expected = _wrapAngle180(lon)
     result = _wrapAngle(lon)
 
-    assert np.allclose(result, expected)
+    np.testing.assert_equal(result, expected)
 
     lon = np.arange(-180, 180)
     expected = _wrapAngle360(lon)
     result = _wrapAngle(lon)
 
-    assert np.allclose(result, expected)
+    np.testing.assert_equal(result, expected)
 
-    raises(ValueError, _wrapAngle, [-1, 181])
+    with pytest.raises(ValueError, match="larger than 180 and smaller than 0"):
+        _wrapAngle([-1, 181])
 
-    raises(ValueError, _wrapAngle, [0, 0])
+    with pytest.raises(ValueError, match="There are equal longitude coordinates"):
+        _wrapAngle([0, 0])
 
     # test explicit argument
     assert _wrapAngle(-1, 180) == -1
@@ -67,3 +83,21 @@ def test__wrapAngle():
     assert _wrapAngle(181, 180) == -179
     assert _wrapAngle(181, 360) == 181
     assert _wrapAngle(181) == -179
+
+
+@pytest.mark.parametrize("wrap_lon", [True, False, 180, 360])
+@pytest.mark.parametrize("lon", ([180.0, 190], [-180, 170]))
+def test_wrapAngle_nan(wrap_lon, lon):
+
+    result = _wrapAngle(lon + [np.NaN], wrap_lon=wrap_lon)[:-1]
+    expected = _wrapAngle(lon, wrap_lon=wrap_lon)
+
+    np.testing.assert_equal(result, expected)
+
+
+# def test_wrapAngle_nan(lon):
+
+#     result = _wrapAngle(lon + [np.NaN], wrap_lon=True)[:-1]
+#     expected = _wrapAngle(lon, wrap_lon=)
+
+#     np.testing.assert_equal(result, expected)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #208
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Fix `_wrapAngle(lon, wrap_lon=True)` when `lon` contains `NA` values. Note however, that this bug would not affect users since v0.8.0 (#271). Also simplifies the logic of the function.