### PR TITLE
mask_geopandas: pass use_cf

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -40,6 +40,10 @@ Breaking Changes
 Enhancements
 ~~~~~~~~~~~~
 
+- Can now pass the ``use_cf`` parameter to :py:func:`mask_geopandas` and :py:func:`mask_3D_geopandas`.
+  This could also be counted as a bug fix as these functions could not control the behavior
+  of finding the coords otherwise(:pull:`427`).
+
 New regions
 ~~~~~~~~~~~
 
@@ -69,10 +73,10 @@ Breaking Changes
 
 - Made more arguments keyword-only for several functions and methods, e.g., for
   :py:meth:`Regions.mask`  (:pull:`368`).
-- Passing `lon_name` and `lat_name` to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
-  is deprecated. Please pass the lon and lat coordinates direcly, e.g., `mask*(ds[lon_name], ds[lat_name])`
+- Passing ``lon_name`` and ``lat_name`` to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
+  is deprecated. Please pass the lon and lat coordinates direcly, e.g., ``mask*(ds[lon_name], ds[lat_name])``
   (:issue:`293` and :pull:`371`).
-- Marked the `method` keyword to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
+- Marked the ``method`` keyword to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
   as internal and flagged it for removal in a future version. Passing this argument should only
   be necessary for testing (:pull:`417`).
 

--- a/regionmask/core/_geopandas.py
+++ b/regionmask/core/_geopandas.py
@@ -223,6 +223,7 @@ def mask_geopandas(
     numbers=None,
     method=None,
     wrap_lon=None,
+    use_cf=None,
 ):
 
     polygons, lon_bounds, numbers = _prepare_gdf_for_mask(
@@ -239,6 +240,7 @@ def mask_geopandas(
         lat_name=lat_name,
         method=method,
         wrap_lon=wrap_lon,
+        use_cf=use_cf,
     )
 
 
@@ -258,6 +260,7 @@ def mask_3D_geopandas(
     method=None,
     wrap_lon=None,
     overlap=False,
+    use_cf=None,
 ):
 
     polygons, lon_bounds, numbers = _prepare_gdf_for_mask(
@@ -276,6 +279,7 @@ def mask_3D_geopandas(
         method=method,
         wrap_lon=wrap_lon,
         as_3D=overlap,
+        use_cf=use_cf,
     )
 
     return mask_3D

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -36,17 +36,21 @@ Parameters
     given. Or an object where the longitude and latitude can be
     retrieved from, either using cf_xarray or by the names "lon"
     and "lat". See also ``use_cf``.
+
 lat : array_like, optional
     If ``lon_or_obj`` is a longitude array, the latitude needs to be
     passed.
+
 {drop_doc}lon_name : str, optional
     Deprecated. Name of longitude in ``lon_or_obj``, default: "lon".
+
 lat_name : str, optional
     Deprecated. Name of latgitude in ``lon_or_obj``, default: "lat"
+
 {numbers_doc}method : "rasterize" | "shapely" | "pygeos". Default: None
-    Method used to determine whether a gridpoint lies in a region.
-    All methods lead to the same mask. If None (default)
-    autoselects the method.
+    Deprecated. Backend used to determine whether a gridpoint lies in a region.
+    All backends lead to the same mask. If None autoselects the backend.
+
 wrap_lon : bool | 180 | 360, optional
     Whether to wrap the longitude around, inferred automatically.
     If the regions and the provided longitude do not have the same
@@ -61,11 +65,18 @@ wrap_lon : bool | 180 | 360, optional
     - ``180``: Wraps longitude coordinates to `[-180, 180[`
     - ``360``: Wraps longitude coordinates to `[0, 360[`
 
-{overlap}{flags}{use_cf}
+{overlap}{flags}use_cf : bool, default: None
+    Whether to use ``cf_xarray`` to infer the names of the x and y coordinates. If None
+    uses cf_xarray if the coord names are unambigous. If True requires cf_xarray if
+    False does not use cf_xarray.
 
 Returns
 -------
 mask_{nd} : {dtype} xarray.DataArray
+
+See Also
+--------
+Regions.{see_also}
 
 References
 ----------
@@ -75,6 +86,7 @@ See https://regionmask.readthedocs.io/en/stable/notebooks/method.html
 _GP_DOCSTRING = """\
 geodataframe : GeoDataFrame or GeoSeries
     Object providing the region definitions (polygons).
+
 """
 
 _NUMBERS_DOCSTRING = """\
@@ -82,6 +94,7 @@ numbers : str, optional
     Name of the column to use for numbering the regions.
     This column must not have duplicates. If None (default),
     takes ``geodataframe.index.values``.
+
 """
 
 
@@ -90,6 +103,7 @@ drop : boolean, default: True
     If True (default) drops slices where all elements are False (i.e no
     gridpoints are contained in a region). If False returns one slice per
     region.
+
 """
 
 _OVERLAP_DOCSTRING = """\
@@ -101,6 +115,7 @@ overlap : bool, default: False
     assigned to the region with the higher number (this may change in a future version).
 
     There is (currently) no automatic detection of overlapping regions.
+
 """
 
 _FLAG_DOCSTRING = """\
@@ -110,26 +125,20 @@ flag : str, default: "abbrevs"
     nothing is added. Using cf_xarray these can be used to select single
     (``mask.cf == "CNA"``) or multiple (``mask.cf.isin``) regions. Note that spaces are
     replaced by underscores.
-"""
 
-_USE_CF_DOCSTRING = """\
-use_cf : bool, default: None
-    Whether to use ``cf_xarray`` to infer the names of the x and y coordinates. If None
-    uses cf_xarray if the coord names are unambigous. If True requires cf_xarray if
-    False does not use cf_xarray.
 """
 
 
 def _inject_mask_docstring(is_3D, gp_method):
 
-    dtype = "float" if is_3D else "boolean"
+    dtype = "boolean" if is_3D else "float"
     nd = "3D" if is_3D else "2D"
     drop_doc = _DROP_DOCSTRING if is_3D else ""
     numbers_doc = _NUMBERS_DOCSTRING if gp_method else ""
     gp_doc = _GP_DOCSTRING if gp_method else ""
     overlap = _OVERLAP_DOCSTRING if (gp_method and is_3D) else ""
     flags = _FLAG_DOCSTRING if not (gp_method or is_3D) else ""
-    use_cf = _USE_CF_DOCSTRING if not gp_method else ""
+    see_also = "mask" if is_3D else "mask_3D"
 
     mask_docstring = _MASK_DOCSTRING_TEMPLATE.format(
         dtype=dtype,
@@ -139,7 +148,7 @@ def _inject_mask_docstring(is_3D, gp_method):
         gp_doc=gp_doc,
         overlap=overlap,
         flags=flags,
-        use_cf=use_cf,
+        see_also=see_also,
     )
 
     return mask_docstring

--- a/regionmask/tests/test_geopandas.py
+++ b/regionmask/tests/test_geopandas.py
@@ -12,8 +12,10 @@ from regionmask.core._geopandas import (
     _enumerate_duplicates,
 )
 
+from . import requires_cf_xarray
 from .utils import (
     dummy_ds,
+    dummy_ds_cf,
     dummy_region,
     dummy_region_overlap,
     expected_mask_2D,
@@ -362,3 +364,24 @@ def test_raise_on_non_numeric_numbers(geodataframe_clean, func):
 
     with pytest.raises(ValueError, match="'numbers' must be numeric"):
         func(geodataframe_clean, dummy_ds.lon, dummy_ds.lat, numbers="abbrevs")
+
+
+@requires_cf_xarray
+@pytest.mark.parametrize("use_cf", (True, None))
+def test_mask_use_cf_mask_2D(geodataframe_clean, use_cf):
+
+    result = mask_geopandas(geodataframe_clean, dummy_ds_cf, use_cf=use_cf)
+
+    expected = expected_mask_2D(lon_name="longitude", lat_name="latitude")
+    xr.testing.assert_equal(result, expected)
+
+
+@requires_cf_xarray
+@pytest.mark.parametrize("use_cf", (True, None))
+def test_mask_use_cf_mask_3D(geodataframe_clean, use_cf):
+
+    result = mask_3D_geopandas(geodataframe_clean, dummy_ds_cf, use_cf=use_cf)
+
+    expected = expected_mask_3D(drop=True, lon_name="longitude", lat_name="latitude")
+    expected = expected.drop_vars(["names", "abbrevs"])
+    xr.testing.assert_equal(result, expected)

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -910,6 +910,7 @@ def test_inject_mask_docstring():
 
     assert "3D" in result
     assert "2D" not in result
+    assert "boolean" in result
     assert "drop :" in result
     assert "geodataframe" in result
     assert "overlap" in result
@@ -918,7 +919,7 @@ def test_inject_mask_docstring():
     result = _inject_mask_docstring(False, False)
 
     assert "2D" in result
-    assert "3D" not in result
+    assert "float" in result
     assert "drop :" not in result
     assert "geodataframe" not in result
     assert "overlap" not in result

--- a/regionmask/tests/test_mask_cf_xarray.py
+++ b/regionmask/tests/test_mask_cf_xarray.py
@@ -2,13 +2,15 @@ import pytest
 import xarray as xr
 
 from . import has_cf_xarray, requires_cf_xarray
-from .utils import dummy_ds, dummy_region, expected_mask_2D, expected_mask_3D
+from .utils import (
+    dummy_ds,
+    dummy_ds_cf,
+    dummy_region,
+    expected_mask_2D,
+    expected_mask_3D,
+)
 
 MASK_METHODS = ["mask", "mask_3D"]
-
-dummy_ds_cf = dummy_ds.rename(lat="latitude", lon="longitude")
-dummy_ds_cf.latitude.attrs["standard_name"] = "latitude"
-dummy_ds_cf.longitude.attrs["standard_name"] = "longitude"
 
 
 @pytest.mark.skipif(has_cf_xarray, reason="must not have cf_xarray")

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -21,6 +21,10 @@ _dummy_lon = [0.5, 1.5]
 _dummy_lat = [0.5, 1.5]
 dummy_ds = xr.Dataset(coords={"lon": _dummy_lon, "lat": _dummy_lat})
 
+dummy_ds_cf = dummy_ds.rename(lat="latitude", lon="longitude")
+dummy_ds_cf.latitude.attrs["standard_name"] = "latitude"
+dummy_ds_cf.longitude.attrs["standard_name"] = "longitude"
+
 
 # in this example the result looks:
 # | a fill |


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

`mask_geopandas` also needs the `use_cf` param - otherwise this behavior cannot be controlled. Also contains doc fixes.