### PR TITLE
finalize plot deprecations

### DIFF
--- a/docs/notebooks/plotting.ipynb
+++ b/docs/notebooks/plotting.ipynb
@@ -134,12 +134,12 @@
     "regions = [11, \"CEU\", \"S. Europe/Mediterranean\"]\n",
     "\n",
     "# choose a good projection for regional maps\n",
-    "proj = ccrs.LambertConformal(central_longitude=15)\n",
+    "projection = ccrs.LambertConformal(central_longitude=15)\n",
     "\n",
     "ax = srex[regions].plot(\n",
     "    add_ocean=True,\n",
     "    resolution=\"50m\",\n",
-    "    proj=proj,\n",
+    "    projection=projection,\n",
     "    label=\"abbrev\",\n",
     "    text_kws=text_kws,\n",
     ")\n",
@@ -211,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -37,6 +37,8 @@ Breaking Changes
   xarray       0.15  0.20
   ============ ===== =====
 
+- Finalize the deprecations for the plot methods from v0.8.0 (:pull:`429`).
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -128,6 +128,7 @@ def _plot(
     line_kws=None,
     text_kws=None,
     resolution="110m",
+    subsample=None,
     add_land=False,
     coastline_kws=None,
     ocean_kws=None,
@@ -269,6 +270,7 @@ def _plot(
         label=label,
         line_kws=line_kws,
         text_kws=text_kws,
+        subsample=subsample,
         label_multipolygon=label_multipolygon,
         tolerance=tolerance,
     )
@@ -334,7 +336,8 @@ def _plot_regions(
 
     if subsample is not None:
         warnings.warn(
-            "The 'subsample' keyword has been deprecated in v0.9.0. Use ``tolerance`` instead.",
+            "The 'subsample' keyword has been deprecated in v0.9.0. Use "
+            "``tolerance`` instead.",
             FutureWarning,
         )
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 
-from ._deprecate import _deprecate_positional_args
 from .utils import _flatten_polygons, flatten_3D_mask
 
 
@@ -117,28 +116,24 @@ def _maybe_gca(**kwargs):
     return plt.axes(**kwargs)
 
 
-@_deprecate_positional_args("0.8.0")
 def _plot(
     self,
     *,
     ax=None,
     projection=None,
-    regions=None,
     add_label=True,
     label="number",
-    add_coastlines=None,
+    add_coastlines=True,
     add_ocean=False,
     line_kws=None,
     text_kws=None,
     resolution="110m",
-    subsample=None,
     add_land=False,
     coastline_kws=None,
     ocean_kws=None,
     land_kws=None,
     label_multipolygon="largest",
     tolerance="auto",
-    **kwargs,
 ):
     """
     plot map with with region outlines
@@ -152,12 +147,6 @@ def _plot(
     projection : cartopy projection, default: None
         Defines the projection of the map. If None uses 'PlateCarree'.
         See cartopy home page.
-
-    regions : list of int or str | 'all', default: 'all'
-        Deprecated - subset regions before plotting, i.e. use `r[regions].plot()`
-        instead of `r.plot(regions=regions)`.
-        Select the regions (by number, abbrev or name, can be mixed)
-        that should be drawn.
 
     add_label : bool, default: True
         If true labels the regions.
@@ -182,9 +171,6 @@ def _plot(
     resolution : '110m' | '50m' | '10m', default: '110m'
         Specify the resolution of the coastline and the ocean dataset.
         See cartopy for details.
-
-    subsample : None or bool, default: None
-        Deprecated, use tolerance.
 
     add_land : bool, default: False
         If true adds the land feature. See land_kws.
@@ -223,31 +209,6 @@ def _plot(
     plot internally calls :py:func:`Regions.plot_regions`.
 
     """
-
-    proj = kwargs.pop("proj", None)
-    if proj is not None:
-        if projection is not None:
-            raise TypeError("Cannot set 'proj' and 'projection'.")
-        projection = proj
-        warnings.warn("'proj' has been renamed to 'projection'", FutureWarning)
-
-    coastlines = kwargs.pop("coastlines", None)
-    if coastlines is not None:
-        if add_coastlines is not None:
-            raise TypeError("Cannot set 'coastlines' and 'add_coastlines'.")
-        add_coastlines = coastlines
-        warnings.warn(
-            "'coastlines' has been renamed to 'add_coastlines'", FutureWarning
-        )
-
-    # part of the deprecation
-    if kwargs:
-        key = list(kwargs.keys())[0]
-        raise TypeError(f"_plot() got an unexpected keyword argument '{key}'")
-
-    # set add_coastlines=True in the fcn signature after the deprecation period
-    if add_coastlines is None:
-        add_coastlines = True
 
     import cartopy.crs as ccrs
     import cartopy.feature as cfeature
@@ -304,12 +265,10 @@ def _plot(
 
     self.plot_regions(
         ax=ax,
-        regions=regions,
         add_label=add_label,
         label=label,
         line_kws=line_kws,
         text_kws=text_kws,
-        subsample=subsample,
         label_multipolygon=label_multipolygon,
         tolerance=tolerance,
     )
@@ -317,12 +276,10 @@ def _plot(
     return ax
 
 
-@_deprecate_positional_args("0.8.0")
 def _plot_regions(
     self,
     *,
     ax=None,
-    regions=None,
     add_label=True,
     label="number",
     line_kws=None,
@@ -340,12 +297,6 @@ def _plot_regions(
         If given, uses existing axes. If not given, uses the current axes or creates new
         axes. In contrast to plot this does not create a cartopy axes.
 
-    regions : list of int or str | 'all', default: "all"
-        Deprecated - subset regions before plotting, i.e. use `r[regions].plot()`
-        instead of `r.plot(regions=regions)`.
-        Select the regions (by number, abbrev or name, can be mixed)
-        that should be drawn.
-
     add_label : bool
         If true labels the regions. Optional, default True.
 
@@ -359,9 +310,6 @@ def _plot_regions(
 
     text_kws : dict, optional
         Arguments passed to the labels (ax.text).
-
-    subsample : None or bool, optional
-        Deprecated, use tolerance.
 
     label_multipolygon : 'largest' | 'all', optional
         If 'largest' only adds a text label for the largest Polygon of a
@@ -384,18 +332,9 @@ def _plot_regions(
 
     """
 
-    if regions is not None:
-        warnings.warn(
-            "The 'regions' keyword has been deprecated. Subset regions before plotting,"
-            " i.e. use `r[regions].plot()` instead of `r.plot(regions=regions)`.",
-            FutureWarning,
-        )
-    else:
-        regions = "all"
-
     if subsample is not None:
         warnings.warn(
-            "The 'subsample' keyword has been deprecated. Use ``tolerance`` instead.",
+            "The 'subsample' keyword has been deprecated in v0.9.0. Use ``tolerance`` instead.",
             FutureWarning,
         )
 
@@ -423,14 +362,6 @@ def _plot_regions(
     else:
         trans = ax.transData
 
-    if regions == "all":
-        regions = self.numbers
-    else:
-        regions = self.map_keys(regions)
-
-    if np.isscalar(regions):
-        regions = [regions]
-
     if line_kws is None:
         line_kws = dict()
 
@@ -441,7 +372,7 @@ def _plot_regions(
         tolerance = None
 
     # draw the outlines
-    polygons = [self[i].polygon for i in regions]
+    polygons = [self[i].polygon for i in self.numbers]
     _draw_poly(ax, polygons, tolerance=tolerance, transform=trans, **line_kws)
 
     if add_label:
@@ -451,7 +382,7 @@ def _plot_regions(
         col = text_kws.pop("backgroundcolor", "0.85")
         clip_on = text_kws.pop("clip_on", True)
 
-        for i in regions:
+        for i in self.numbers:
             r = self[i]
             txt = str(getattr(r, label))
 

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -246,19 +246,6 @@ def test_plot_regions_gca():
 
 
 @requires_cartopy
-def test_plot_deprecated_proj():
-
-    proj = ccrs.PlateCarree()
-    with pytest.warns(FutureWarning, match="'proj' has been renamed to 'projection'"):
-        with figure_context():
-            ax = r1.plot(tolerance=None, proj=proj)
-            assert isinstance(ax.projection, ccrs.PlateCarree)
-
-    with pytest.raises(TypeError, match="Cannot set 'proj' and 'projection'"):
-        r1.plot(tolerance=None, proj=proj, projection=proj)
-
-
-@requires_cartopy
 def test_plot_regions_projection():
 
     # if none is given -> no projection
@@ -314,60 +301,16 @@ def test_plot_lines_multipoly(plotfunc):
 
 @requires_matplotlib
 @pytest.mark.parametrize("plotfunc", PLOTFUNCS)
-@pytest.mark.filterwarnings("ignore:The 'regions' keyword has been deprecated")
 def test_plot_lines_selection(plotfunc):
 
-    func = getattr(r1, plotfunc)
-
     with figure_context():
-        ax = func(tolerance=None, regions=[0, 1])
+        func = getattr(r1[0, 1], plotfunc)
+
+        ax = func(tolerance=None)
         lines = ax.collections[0].get_segments()
         assert len(lines) == 2
         assert np.allclose(lines[0], outl1_closed)
         assert np.allclose(lines[1], outl2_closed)
-
-    # select a single number
-    with figure_context():
-        ax = func(tolerance=None, regions=0)
-        lines = ax.collections[0].get_segments()
-        assert len(lines) == 1
-        assert np.allclose(lines[0], outl1_closed)
-
-    # select by number
-    with figure_context():
-        ax = func(tolerance=None, regions=[0])
-        lines = ax.collections[0].get_segments()
-        assert len(lines) == 1
-        assert np.allclose(lines[0], outl1_closed)
-
-    # select by long_name
-    with figure_context():
-        ax = func(tolerance=None, regions=["Unit Square1"])
-        lines = ax.collections[0].get_segments()
-        assert len(lines) == 1
-        assert np.allclose(lines[0], outl1_closed)
-
-    # select by abbreviation
-    with figure_context():
-        ax = func(tolerance=None, regions=["uSq1"])
-        lines = ax.collections[0].get_segments()
-        assert len(lines) == 1
-        assert np.allclose(lines[0], outl1_closed)
-
-
-@requires_matplotlib
-@pytest.mark.parametrize("plotfunc", PLOTFUNCS)
-def test_plot_regions_kw_deprecated(plotfunc):
-
-    func = getattr(r1, plotfunc)
-
-    with pytest.warns(FutureWarning, match="The 'regions' keyword has been deprecated"):
-        with figure_context():
-            func(tolerance=None, regions=[0, 1])
-
-    with pytest.warns(FutureWarning, match="The 'regions' keyword has been deprecated"):
-        with figure_context():
-            func(tolerance=None, regions="all")
 
 
 @requires_matplotlib
@@ -382,17 +325,6 @@ def test_error_extra_kwarg():
 
 
 # -----------------------------------------------------------------------------
-
-
-@requires_matplotlib
-@pytest.mark.parametrize("plotfunc", PLOTFUNCS)
-def test_plot_deprecate_args(plotfunc):
-
-    func = getattr(r1, plotfunc)
-
-    with pytest.warns(FutureWarning, match="Passing 'ax' as positional"):
-        with figure_context():
-            func(None)
 
 
 @requires_matplotlib
@@ -452,20 +384,6 @@ def test_plot_regions_lines_tolerance_cartopy_axes():
         lines = ax.collections[0].get_paths()
         np.testing.assert_allclose(lines[0].vertices.shape, expected)
         np.testing.assert_allclose(lines[1].vertices.shape, expected)
-
-
-@requires_matplotlib
-@pytest.mark.parametrize("plotfunc", PLOTFUNCS)
-@pytest.mark.parametrize("subsample", [True, False])
-def test_plot_lines_subsample_deprecated(plotfunc, subsample):
-
-    func = getattr(r1, plotfunc)
-
-    with pytest.warns(
-        FutureWarning, match="The 'subsample' keyword has been deprecated."
-    ):
-        with figure_context():
-            func(subsample=subsample)
 
 
 # -----------------------------------------------------------------------------
@@ -730,21 +648,6 @@ def test_plot_add_coastlines():
         assert len(ax.artists) == 1
         art = ax.artists[0]
         assert art._kwargs == {"edgecolor": "black", "facecolor": "none"}
-
-
-@requires_matplotlib
-@requires_cartopy
-def test_plot_coastlines_deprecated():
-
-    kwargs = dict(tolerance=None, add_label=False)
-
-    with pytest.warns(FutureWarning, match="'coastlines' has been renamed"):
-        with figure_context():
-            ax = r1.plot(coastlines=True, **kwargs)
-            assert len(ax.artists) == 1
-
-    with pytest.raises(TypeError, match="Cannot set 'coastlines' and 'add_coastlines'"):
-        ax = r1.plot(add_coastlines=False, coastlines=True, **kwargs)
 
 
 @requires_matplotlib

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -386,6 +386,20 @@ def test_plot_regions_lines_tolerance_cartopy_axes():
         np.testing.assert_allclose(lines[1].vertices.shape, expected)
 
 
+@requires_matplotlib
+@pytest.mark.parametrize("plotfunc", PLOTFUNCS)
+@pytest.mark.parametrize("subsample", [True, False])
+def test_plot_lines_subsample_deprecated(plotfunc, subsample):
+
+    func = getattr(r1, plotfunc)
+
+    with pytest.warns(
+        FutureWarning, match="The 'subsample' keyword has been deprecated."
+    ):
+        with figure_context():
+            func(subsample=subsample)
+
+
 # -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Finalize the deprecations for the plot methods in v0.8.0. 