### PR TITLE
remote ressources: version github url

### DIFF
--- a/regionmask/defined_regions/_ressources.py
+++ b/regionmask/defined_regions/_ressources.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import geopandas as gp
 import pooch
 
+import regionmask
 from regionmask.core.options import OPTIONS
 
 
@@ -21,11 +22,13 @@ def fetch_remote_shapefile(name):
         # Use the default cache folder for the OS
         path=_get_cache_dir(),
         # The remote data is on Github
-        base_url="https://github.com/regionmask/regionmask/raw/main/data/",
+        base_url="https://github.com/regionmask/regionmask/raw/{version}/data/",
         registry={
             "IPCC-WGI-reference-regions-v4.zip": "c83881a18e74912385ad578282de721cc8e866b62cbbc75446e52e7041c81cff",
             "IPCC-WGI-reference-regions-v1.zip": "8507cef52057785117cabc83d6e03414b5994745bf7f297c179eb50507f7ee89",
         },
+        version=f"v{regionmask.__version__}",
+        version_dev="main",
     )
 
     # the file will be downloaded automatically the first time this is run.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Update the target url of the remote resources: now uses the version in the github url. So I can enventually remove master and the ar6 pre-revision data file. I should have done this long ago, that would also have eased the master -> main transition (probably).