### PR TITLE
buxfix for unstructured & overlapping masks

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -52,6 +52,8 @@ New regions
 Bug Fixes
 ~~~~~~~~~
 
+- Fix a bug which raises an error when trying to creating a mask for overlapping regions
+  and unstructured coordinates (:issue:`438`).
 - Fix the detection of edge points at -180°E or 0°E if longitude values contain ``NA``
   values (:issue:`426`).
 - Fix the wrapping of longitudes that contain ``NA`` values and simplify the ``_wrapAngle``

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -701,7 +701,7 @@ def _get_LON_LAT_shape(lon, lat, numbers, is_unstructured=False, as_3D=False):
 def _get_out(shape, fill, as_3D):
     # create flattened output variable
     if as_3D:
-        out = np.full(shape[:1] + (np.prod(shape[-2:]).item(),), False, bool)
+        out = np.full(shape[:1] + (np.prod(shape[1:]).item(),), False, bool)
     else:
         out = np.full(np.prod(shape), fill, float)
 

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -367,6 +367,24 @@ def test_mask_3D_overlap_empty(method):
     assert not result.any()
 
 
+@pytest.mark.parametrize("drop", [True, False])
+@pytest.mark.parametrize("method", MASK_METHODS_IRREGULAR)
+def test_mask_overlap_unstructured(drop, method):
+    """Test for unstructured output."""
+    lat = [0.5, 0.5, 1.5, 1.5]
+    lon = [0.5, 1.5, 0.5, 1.5]
+
+    coords = {"lon": ("cells", lon), "lat": ("cells", lat)}
+    grid = xr.Dataset(coords=coords)
+
+    result = dummy_region_overlap.mask_3D(grid, drop=drop, method=method)
+
+    expected = expected_mask_3D(drop=drop, overlap=True)
+    expected = expected.stack(cells=("lat", "lon")).reset_index("cells")
+
+    xr.testing.assert_equal(result, expected)
+
+
 def test_mask_flag():
 
     expected = expected_mask_2D()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #438
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Not difficult to fix, but easy to miss... Reminds me very much of #266 (where a `-` was missing)
