### PR TITLE
fix test for matplotlib v3.8

### DIFF
--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -687,7 +687,7 @@ def test_plot_3D_mask_wrong_input():
 
     expected = np.ma.masked_invalid(mask_2D.values)
 
-    if Version(mpl.__version__) <= Version("3.8"):
+    if Version(mpl.__version__) > Version("3.7"):
         expected = expected.ravel()
 
     with figure_context():

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -1,3 +1,5 @@
+
+from packaging.version import Version
 import contextlib
 
 try:
@@ -683,7 +685,11 @@ def test_plot_3D_mask_wrong_input():
     with pytest.raises(ValueError, match="must contain the dimension 'region'"):
         plot_3D_mask(mask_2D.expand_dims("foo"))
 
-    expected = np.ma.masked_invalid(mask_2D.values).flatten()
+    expected = np.ma.masked_invalid(mask_2D.values)
+
+    if Version(mpl.__version__) < Version("3.8"):
+        expected = expected.ravel()
+
     with figure_context():
         h = plot_3D_mask(mask_3D, zorder=3)
 

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -1,6 +1,6 @@
+import contextlib
 
 from packaging.version import Version
-import contextlib
 
 try:
     import cartopy.crs as ccrs

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -687,7 +687,7 @@ def test_plot_3D_mask_wrong_input():
 
     expected = np.ma.masked_invalid(mask_2D.values)
 
-    if Version(mpl.__version__) < Version("3.8"):
+    if Version(mpl.__version__) <= Version("3.8"):
         expected = expected.ravel()
 
     with figure_context():

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -687,7 +687,7 @@ def test_plot_3D_mask_wrong_input():
 
     expected = np.ma.masked_invalid(mask_2D.values)
 
-    if Version(mpl.__version__) > Version("3.7.99"):
+    if Version(mpl.__version__) < Version("3.7.99"):
         expected = expected.ravel()
 
     with figure_context():

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -687,7 +687,7 @@ def test_plot_3D_mask_wrong_input():
 
     expected = np.ma.masked_invalid(mask_2D.values)
 
-    if Version(mpl.__version__) > Version("3.7"):
+    if Version(mpl.__version__) > Version("3.7.99"):
         expected = expected.ravel()
 
     with figure_context():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #446
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
