### PR TITLE
BUG: more than 32 overlapping regions using rasterio

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -54,8 +54,11 @@ New regions
 Bug Fixes
 ~~~~~~~~~
 
-- Fix a bug which raises an error when trying to creating a mask for overlapping regions
-  and unstructured coordinates (:issue:`438`).
+- Fixed two bugs, which would raise an error when creating a mask for overlapping regions if:
+
+  - the coordinates were unstructured (:issue:`438`)
+  - there were more than 32 regions and equally-spaced coordinates (:issue:`453`).
+
 - Fix the detection of edge points at -180°E or 0°E if longitude values contain ``NA``
   values (:issue:`426`).
 - Fix the wrapping of longitudes that contain ``NA`` values and simplify the ``_wrapAngle``

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -865,7 +865,7 @@ def _mask_rasterize_3D_internal(lon, lat, polygons, **kwargs):
         result = result.transpose([2, 0, 1])
         out.append(result)
 
-    return np.concatenate(out, axis=2)[:n_polygons, ...]
+    return np.concatenate(out, axis=0)[:n_polygons, ...]
 
 
 def _mask_rasterize_internal(lon, lat, polygons, numbers, fill=np.nan, **kwargs):

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from affine import Affine
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, box
 
 from regionmask import Regions
 from regionmask.core.mask import (
@@ -385,6 +385,24 @@ def test_mask_3D_overlap_one(drop, method):
     result = dummy_region_overlap.mask_3D(dummy_ds, drop=drop, method=method)
 
     xr.testing.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("wrap_lon", [None, True, False])
+@pytest.mark.parametrize("method", MASK_METHODS)
+def test_mask_3D_overlap_more_than_64(wrap_lon, method):
+
+    polygon = box(0, 0, 5, 5)
+
+    lon = np.arange(0.5, 5)
+    lat = np.arange(0.5, 5)
+
+    region = Regions([polygon] * 65, overlap=True)
+
+    result = region.mask_3D(lon, lat, wrap_lon=wrap_lon, method=method)
+
+    expected = xr.ones_like(result, dtype=bool)
+
+    xr.testing.assert_identical(expected, result)
 
 
 @pytest.mark.parametrize("drop", [True, False])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes  #453
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`
