### PR TITLE
drop python 3.8 support

### DIFF
--- a/.github/workflows/ci-additional.yaml
+++ b/.github/workflows/ci-additional.yaml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         include:
           - env: "bare-minimum"
-            python-version: "3.8"
+            python-version: "3.9"
           - env: "min-all-deps"
-            python-version: "3.8"
+            python-version: "3.9"
           - env: "shapely_lt_2"
             python-version: "3.10"
     steps:
@@ -101,4 +101,4 @@ jobs:
 
       - name: minimum versions policy
         run: |
-          python ci/min_deps_check.py ci/requirements/py38-min-all-deps.yml
+          python ci/min_deps_check.py ci/requirements/py39-min-all-deps.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # Bookend python versions
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.9", "3.11"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # Bookend python versions
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ v0.12.0 (unreleased)
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- Removed support for Python 3.7 (:pull:`465`).
+- Removed support for Python 3.8 (:pull:`465`).
 
 Enhancements
 ~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ v0.12.0 (unreleased)
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
+- Removed support for Python 3.7 (:pull:`465`).
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -10,8 +10,8 @@ policy on obsolete dependencies is being followed. Print a pretty report :)
 
 import itertools
 import sys
-from datetime import datetime
 from collections.abc import Iterator
+from datetime import datetime
 
 import conda.api  # type: ignore[import]
 import yaml

--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -11,7 +11,7 @@ policy on obsolete dependencies is being followed. Print a pretty report :)
 import itertools
 import sys
 from datetime import datetime
-from typing import Iterator
+from collections.abc import Iterator
 
 import conda.api  # type: ignore[import]
 import yaml

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - python=3.10
+  - python=3.11
 # regionmask dependencies
   - cartopy
   - geopandas

--- a/ci/requirements/py39-bare-minimum.yml
+++ b/ci/requirements/py39-bare-minimum.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.8
+  - python=3.9
   - geopandas
   - numpy
   - packaging

--- a/ci/requirements/py39-min-all-deps.yml
+++ b/ci/requirements/py39-min-all-deps.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.8
+  - python=3.9
   - cartopy=0.20
   - cf_xarray=0.7
   - geopandas=0.10

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python (3.8 or later)
+- Python (3.9 or later)
 - `geopandas <http://geopandas.org/>`__ (0.10 or later)
 - `numpy <http://www.numpy.org/>`__ (1.21 or later)
 - `packaging <https://packaging.pypa.io/en/latest/>`__ (21.3 or later)

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -1,7 +1,7 @@
 import warnings
 from dataclasses import dataclass
 from functools import partial
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 import pytest

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -97,7 +97,7 @@ class DefinedRegion:
     n_regions: int
     overlap: bool = False
     skip_mask_test: bool = False
-    bounds: Optional[List[float]] = None
+    bounds: Optional[list[float]] = None
 
     def __str__(self):
         # used as name (`ids`) for parametrize

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -26,7 +25,7 @@ classifiers =
 packages = find:
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     geopandas >= 0.10
     numpy >= 1.21


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Drop support for python 3.8 as mandated by NEP 29.