### PR TITLE
fix overlap default and docstring in from_* methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,11 +32,14 @@ New regions
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed the default value of ``overlap`` of :py:func:`from_geopandas` to ``None`` (:issue:`453`, :pull:`470`).
+
 Docs
 ~~~~
 
 - Updated the "Using regionmask with intake" example (:pull:`477`).
 - Fixed the url to the MEOW dataset in the intake example (:pull:`474` and :pull:`477`).
+- Fixed the docstring for ``overlap`` of :py:func:`from_geopandas` and :py:class:`Regions` (:issue:`453`, :pull:`470`).
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/regionmask/core/_geopandas.py
+++ b/regionmask/core/_geopandas.py
@@ -68,7 +68,7 @@ def from_geopandas(
     abbrevs=None,
     name="unnamed",
     source=None,
-    overlap=False,
+    overlap=None,
 ):
     """
     Create ``regionmask.Regions`` from a ``geopandas.GeoDataFrame``.
@@ -98,16 +98,18 @@ def from_geopandas(
     source : str, optional
         source of the shapefile
 
-    overlap : bool, default: False
-        Indicates if (some of) the regions overlap. If True ``mask_3D`` will ensure
-        overlapping regions are correctly assigned to grid points while ``mask`` will
-        error (because overlapping regions cannot be represented by a 2D mask).
+    overlap : bool | None, default: None
+        Indicates if (some of) the regions overlap and determines the behaviour of the
+        ``mask`` methods.
 
-        If False (default) assumes non-overlapping regions. Grid points will
-        silently be assigned to the region with the higher number (this may change
-        in a future version).
-
-        There is (currently) no automatic detection of overlapping regions.
+        - If True ``mask_3D`` ensures overlapping regions are correctly assigned
+          to grid points, while ``mask`` raises an Error (because overlapping
+          regions cannot be represented by a 2 dimensional mask).
+        - If False assumes non-overlapping regions. Grid points are silently assigned to the
+          region with the higher number.
+        - If None (default) checks if any gridpoint belongs to more than one region.
+          If this is the case ``mask_3D`` correctly assigns them and ``mask``
+          raises an Error.
 
     Returns
     -------

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -496,13 +496,13 @@ class Regions:
             ``mask`` methods.
 
             - If True ``mask_3D`` ensures overlapping regions are correctly assigned
-            to grid points, while ``mask`` raises an Error (because overlapping
-            regions cannot be represented by a 2 dimensional mask).
+              to grid points, while ``mask`` raises an Error (because overlapping
+              regions cannot be represented by a 2 dimensional mask).
             - If False assumes non-overlapping regions. Grid points are silently assigned to the
-            region with the higher number.
+              region with the higher number.
             - If None (default) checks if any gridpoint belongs to more than one region.
-            If this is the case ``mask_3D`` correctly assigns them and ``mask``
-            raises an Error.
+              If this is the case ``mask_3D`` correctly assigns them and ``mask``
+              raises an Error.
 
         Returns
         -------

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -37,10 +37,11 @@ class Regions:
     source : string, optional
         Source of the region definitions. Default: "".
     overlap : bool | None, default: None
-        Indicates if (some of) the regions overlap.
+        Indicates if (some of) the regions overlap  and determines the behaviour of the
+        ``mask`` methods.
 
         - If True ``Regions.mask_3D`` ensures overlapping regions are correctly assigned
-          to grid points, while ``Regionsmask`` raises an Error  (because overlapping
+          to grid points, while ``Regions.mask`` raises an Error  (because overlapping
           regions cannot be represented by a 2D mask).
         - If False assumes non-overlapping regions. Grid points are silently assigned to
           the region with the higher number.
@@ -490,17 +491,18 @@ class Regions:
         source : str, optional
             Source of the shapefile.  If None uses ``df.attrs.get("source")``.
 
-        overlap : bool, default: None
-            Indicates if (some of) the regions overlap. If None uses
-            ``df.attrs.get("overlap")``. If True ``mask_3D`` will ensure
-            overlapping regions are correctly assigned to grid points while ``mask``
-            will error (because overlapping regions cannot be represented by a 2D mask).
+        overlap : bool | None, default: None
+            Indicates if (some of) the regions overlap and determines the behaviour of the
+            ``mask`` methods.
 
-            If False assumes non-overlapping regions. Grid points will silently be
-            assigned to the region with the higher number (this may change in a future
-            version).
-
-            There is (currently) no automatic detection of overlapping regions.
+            - If True ``mask_3D`` ensures overlapping regions are correctly assigned
+            to grid points, while ``mask`` raises an Error (because overlapping
+            regions cannot be represented by a 2 dimensional mask).
+            - If False assumes non-overlapping regions. Grid points are silently assigned to the
+            region with the higher number.
+            - If None (default) checks if any gridpoint belongs to more than one region.
+            If this is the case ``mask_3D`` correctly assigns them and ``mask``
+            raises an Error.
 
         Returns
         -------
@@ -520,7 +522,7 @@ class Regions:
             source = df.attrs.get("source")
 
         if overlap is None:
-            overlap = df.attrs.get("overlap", False)
+            overlap = df.attrs.get("overlap", None)
 
         return _from_geopandas(
             df,

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -410,10 +410,11 @@ def test_from_geodataframe():
     r = Regions.from_geodataframe(df)
     assert r.name == "unnamed"
     assert r.source is None
-    assert r.overlap is False
+    assert r.overlap is None
 
 
-def test_from_geodataframe_roundtrip():
+@pytest.mark.parametrize("overlap", [True, False, None])
+def test_from_geodataframe_roundtrip(overlap):
 
     import geopandas
 
@@ -421,7 +422,7 @@ def test_from_geodataframe_roundtrip():
 
     df = geopandas.GeoDataFrame(data=data, geometry=[poly1, poly2], index=numbers2)
     df.index.name = "numbers"
-    df.attrs = dict(source="source", name=name, overlap=True)
+    df.attrs = dict(source="source", name=name, overlap=overlap)
 
     r = Regions.from_geodataframe(df)
 

--- a/regionmask/tests/test_geopandas.py
+++ b/regionmask/tests/test_geopandas.py
@@ -106,6 +106,7 @@ def test_from_geopandas_use_columns(geodataframe_clean):
     assert result.abbrevs == ["uSq1", "uSq2", "uSq3"]
     assert result.name == "name"
     assert result.source == "source"
+    assert result.overlap is None
 
 
 @pytest.mark.parametrize("attr", ["name", "source", "overlap"])
@@ -133,7 +134,10 @@ def test_from_geopandas_default(geodataframe_clean):
     assert result.names == ["Region0", "Region1", "Region2"]
     assert result.abbrevs == ["r0", "r1", "r2"]
     assert result.name == "unnamed"
-    assert result.source is None
+    assert result.overlap is None
+
+    result = from_geopandas(geodataframe_clean, overlap=True)
+    assert result.overlap is True
 
 
 @pytest.mark.parametrize("arg", ["names", "abbrevs", "numbers"])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #469
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`
