### PR TITLE
ignore __version__ fallback in coverage

### DIFF
--- a/regionmask/__init__.py
+++ b/regionmask/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 
 try:
     __version__ = _get_version("regionmask")
-except Exception:
+except Exception:  # pragma: no cover
     # Local copy or not installed with setuptools.
     # Disable minimum version checks on downstream libraries.
     __version__ = "999"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Towards #471
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

