### PR TITLE
Edge problem lon=180

### DIFF
--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -27,6 +27,9 @@ except ModuleNotFoundError:
 
 has_shapely_2 = Version(shapely.__version__) > Version("2.0b1")
 
+lon_tiny_offset = -1e-4
+lat_tiny_offset = -1e-4
+
 _MASK_DOCSTRING_TEMPLATE = """\
 create a {nd} {dtype} mask of a set of regions for the given lat/ lon grid
 
@@ -587,8 +590,8 @@ def _mask_edgepoints_shapely(
         return mask.reshape(shape)
 
     # add a tiny offset to get a consistent edge behaviour
-    LON = LON[borderpoints] - 1 * 10**-8
-    LAT = LAT[borderpoints] - 1 * 10**-10
+    LON = LON[borderpoints] - lon_tiny_offset
+    LAT = LAT[borderpoints] - lat_tiny_offset
 
     # wrap points LON_180W_or_0E: -180°E -> 180°E and 0°E -> 360°E
     LON[LON_180W_or_0E[borderpoints]] += 360
@@ -623,8 +626,8 @@ def _mask_pygeos(
     out = _get_out(shape, fill, as_3D=as_3D)
 
     # add a tiny offset to get a consistent edge behaviour
-    LON = LON - 1 * 10**-8
-    LAT = LAT - 1 * 10**-10
+    LON = LON - lon_tiny_offset
+    LAT = LAT - lat_tiny_offset
 
     # convert shapely points to pygeos
     poly_pygeos = pygeos.from_shapely(polygons)
@@ -656,8 +659,8 @@ def _mask_shapely_v2(
     out = _get_out(shape, fill, as_3D=as_3D)
 
     # add a tiny offset to get a consistent edge behaviour
-    LON = LON - 1 * 10**-8
-    LAT = LAT - 1 * 10**-10
+    LON = LON - lon_tiny_offset
+    LAT = LAT - lat_tiny_offset
 
     # convert shapely points to pygeos
     points = shapely.points(LON, LAT)
@@ -690,8 +693,8 @@ def _mask_shapely(
     out = _get_out(shape, fill, as_3D=as_3D)
 
     # add a tiny offset to get a consistent edge behaviour
-    LON = LON - 1 * 10**-8
-    LAT = LAT - 1 * 10**-10
+    LON = LON - lon_tiny_offset
+    LAT = LAT - lat_tiny_offset
 
     if as_3D:
         for i, polygon in enumerate(polygons):
@@ -877,8 +880,8 @@ def _mask_rasterize_internal(lon, lat, polygons, numbers, fill=np.nan, **kwargs)
     lon, lat = _parse_input(lon, lat, polygons, fill, numbers)
 
     # subtract a tiny offset: https://github.com/mapbox/rasterio/issues/1844
-    lon = lon - 1 * 10**-8
-    lat = lat - 1 * 10**-10
+    lon = lon - lon_tiny_offset
+    lat = lat - lat_tiny_offset
 
     return _mask_rasterize_no_offset(lon, lat, polygons, numbers, fill, **kwargs)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
## Edge problem
Similar example at https://github.com/regionmask/regionmask/issues/410#issue-1687496840

![image](https://github.com/regionmask/regionmask/assets/24798748/16319b1c-85b5-4a3c-92fa-d2d554c9ca31)

```
import xarray as xr
import numpy as np

import regionmask

def gengrid_global(dlon=1, dlat=1):
    lat_out  = xr.DataArray( np.arange(-90, 90.1, dlat, dtype = np.float64), dims = ['lat'], name = ['lat'], 
                         attrs = {'long_name':'latitude', 'units': 'degrees_north', 'axis': 'Y'} )
    lon_out  = xr.DataArray( np.arange(0, 360, dlon, dtype = np.float64), dims = ['lon'], name = ['lon'], 
                         attrs = {'long_name':'longitude', 'units': 'degrees_east', 'axis': 'X'} )
    global_grid = xr.Dataset( {'lat': lat_out , 'lon': lon_out,})
    global_grid['lat'].encoding['_FillValue'] = None
    global_grid['lon'].encoding['_FillValue'] = None
    return global_grid

ds = gengrid_global(dlat=1, dlon=1)

basins = regionmask.defined_regions.natural_earth_v4_1_0.ocean_basins_50
mask_full = basins.mask(ds )
mask_full.plot(cmap='tab20', vmin=0, vmax=20)`
```

Although I found https://github.com/regionmask/regionmask/blob/629d696f36193cf62281204061b3998510e2d71a/regionmask/core/mask.py#L589C1-L591C42 has a tiny treatment to keep it consistent, however, it seems not be working out!

## Modification and Tests
add variables lon_tiny_offset and lat_tiny_offset, change them to negative values of 1e-4.

![image](https://github.com/regionmask/regionmask/assets/24798748/39071d9d-7774-4c7e-a4aa-180f7d29bc47)

I also tested 1e-5 or smaller magnitude, it is not working either. 
