### PR TITLE
optimize `Regions` and allow float numbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,8 @@ Docs
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Small optimizations for :py:class:`Regions` (:pull:`#478`).
+
 
 v0.11.0 (22.09.2023)
 --------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -116,7 +116,6 @@ Attributes
    :toctree: generated/
 
    _OneRegion.coords
-   _OneRegion.polygon
    _OneRegion.bounds
 
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -365,8 +365,7 @@ def _plot_regions(
         tolerance = None
 
     # draw the outlines
-    polygons = [self[i].polygon for i in self.numbers]
-    _draw_poly(ax, polygons, tolerance=tolerance, transform=trans, **line_kws)
+    _draw_poly(ax, self.polygons, tolerance=tolerance, transform=trans, **line_kws)
 
     if add_label:
 

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -211,11 +211,6 @@ class Regions:
     def __iter__(self):
         yield from self.regions.values()
 
-    def combiner(self, prop):
-        """combines attributes from single regions"""
-
-        return [getattr(r, prop) for r in self.regions.values()]
-
     @property
     def region_ids(self):
         """dictionary that maps all names and abbrevs to the region number"""

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -14,7 +14,13 @@ from ._deprecate import _deprecate_positional_args
 from .formatting import _display
 from .mask import _inject_mask_docstring, _mask_2D, _mask_3D
 from .plot import _plot, _plot_regions
-from .utils import _is_180, _is_numeric, _maybe_to_dict, _sanitize_names_abbrevs, _total_bounds
+from .utils import (
+    _is_180,
+    _is_numeric,
+    _maybe_to_dict,
+    _sanitize_names_abbrevs,
+    _total_bounds,
+)
 
 
 class Regions:
@@ -625,7 +631,6 @@ class _OneRegion:
         """numpy array of the region"""
 
         if self._coords is None:
-
 
             if isinstance(self.polygon, Polygon):
                 coords = np.array(self.polygon.exterior.coords)

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -637,20 +637,21 @@ class _OneRegion:
             else:
                 polys = self.polygon.geoms
 
-                # separate the single polygons with NaNs
+                # separate the single polygons with nans
                 nan = np.full((1, 2), np.nan)
-
                 coords = [c for poly in polys for c in (poly.exterior.coords, nan)]
+                # remove the last nan and stack
                 coords = np.vstack(coords[:-1])
 
-            # remove the very last nan and stack
             self._coords = coords
 
         return self._coords
 
     @property
     def bounds(self):
-        """bounds of the regions ((Multi)Polygon.bounds (min_lon, min_lat, max_lon, max_lat)"""
+        """
+        bounds of the regions (Multi)Polygon.bounds (min_lon, min_lat, max_lon, max_lat)
+        """
         if self._bounds is None:
             self._bounds = self.polygon.bounds
         return self._bounds

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -14,7 +14,7 @@ from ._deprecate import _deprecate_positional_args
 from .formatting import _display
 from .mask import _inject_mask_docstring, _mask_2D, _mask_3D
 from .plot import _plot, _plot_regions
-from .utils import _is_180, _is_numeric, _maybe_to_dict, _sanitize_names_abbrevs
+from .utils import _is_180, _is_numeric, _maybe_to_dict, _sanitize_names_abbrevs, _total_bounds
 
 
 class Regions:
@@ -163,7 +163,7 @@ class Regions:
         """
 
         key = self.map_keys(key)
-        if isinstance(key, (int, np.integer)):
+        if np.ndim(key) == 0:
             return self.regions[key]
         else:
             # subsample the regions
@@ -173,7 +173,7 @@ class Regions:
             return new_self
 
     def __len__(self):
-        return len(self.numbers)
+        return len(self.regions)
 
     def map_keys(self, key):
         """map from names and abbrevs of the regions to numbers
@@ -192,7 +192,7 @@ class Regions:
         """
 
         # a single key
-        if isinstance(key, (int, np.integer, str)):
+        if np.ndim(key) == 0:
             key = self.region_ids[key]
         # a list of keys
         else:
@@ -203,8 +203,7 @@ class Regions:
         return key
 
     def __iter__(self):
-        for i in self.numbers:
-            yield self[i]
+        yield from self.regions.values()
 
     def combiner(self, prop):
         """combines attributes from single regions"""
@@ -227,56 +226,48 @@ class Regions:
     @property
     def abbrevs(self):
         """list of abbreviations of the regions"""
-        return self.combiner("abbrev")
+        return [r.abbrev for r in self.regions.values()]
 
     @property
     def names(self):
         """list of names of the regions"""
-        return self.combiner("name")
+        return [r.name for r in self.regions.values()]
 
     @property
     def numbers(self):
         """list of the numbers of the regions"""
-        return self.combiner("number")
+        return [r.number for r in self.regions.values()]
 
     @property
     def coords(self):
         """list of coordinates of the region vertices as numpy array"""
-        return self.combiner("coords")
+        return [r.coords for r in self.regions.values()]
 
     @property
     def polygons(self):
         """list of shapely Polygon/ MultiPolygon of the regions"""
-        return self.combiner("polygon")
+        return [r.polygon for r in self.regions.values()]
 
     @property
     def centroids(self):
         """list of the center of mass of the regions"""
-        return self.combiner("centroid")
+        return [r.centroid for r in self.regions.values()]
 
     @property
     def bounds(self):
         """list of the bounds of the regions (min_lon, min_lat, max_lon, max_lat)"""
-        return self.combiner("bounds")
+        return [r.bounds for r in self.regions.values()]
 
     @property
     def bounds_global(self):
         """global bounds over all regions (min_lon, min_lat, max_lon, max_lat)"""
 
-        bounds = self.bounds
-
-        xmin = np.min([p[0] for p in bounds])
-        ymin = np.min([p[1] for p in bounds])
-        xmax = np.max([p[2] for p in bounds])
-        ymax = np.max([p[3] for p in bounds])
-
-        return [xmin, ymin, xmax, ymax]
+        return _total_bounds(self.polygons)
 
     @property
     def lon_180(self):
         """if the regions extend from -180 to 180"""
-        lon_min = self.bounds_global[0]
-        lon_max = self.bounds_global[2]
+        lon_min, __, lon_max, __ = self.bounds_global
 
         return _is_180(lon_min, lon_max)
 
@@ -583,10 +574,10 @@ class _OneRegion:
         self._bounds = None
 
         if isinstance(outline, (Polygon, MultiPolygon)):
-            self._polygon = outline
+            self.polygon = outline
             self._coords = None
         else:
-            self._polygon = None
+
             outline = np.asarray(outline)
 
             if outline.ndim != 2:
@@ -598,6 +589,7 @@ class _OneRegion:
             if outline.shape[1] != 2:
                 raise ValueError("Outline must have Nx2 elements")
 
+            self.polygon = Polygon(outline)
             self._coords = outline
 
     def __repr__(self):
@@ -612,7 +604,7 @@ class _OneRegion:
         if self._centroid is None:
             poly = self.polygon
             if isinstance(poly, MultiPolygon):
-                # find the polygon with the largest area and assig as centroid
+                # find the polygon with the largest area and assign as centroid
                 area = 0
                 for p in poly.geoms:
                     if p.area > area:
@@ -629,31 +621,25 @@ class _OneRegion:
         return self._centroid
 
     @property
-    def polygon(self):
-        """shapely Polygon or MultiPolygon of the region"""
-
-        if self._polygon is None:
-            self._polygon = Polygon(self.coords)
-        return self._polygon
-
-    @property
     def coords(self):
         """numpy array of the region"""
 
         if self._coords is None:
 
-            # make an array of polygons
-            if isinstance(self._polygon, Polygon):
-                polys = [self._polygon]
+
+            if isinstance(self.polygon, Polygon):
+                coords = np.array(self.polygon.exterior.coords)
             else:
-                polys = list(self._polygon.geoms)
+                polys = self.polygon.geoms
 
-            # separate the single polygons with NaNs
-            nan = np.full((1, 2), np.nan)
-            lst = [np.vstack((np.array(poly.exterior.coords), nan)) for poly in polys]
+                # separate the single polygons with NaNs
+                nan = np.full((1, 2), np.nan)
 
-            # remove the very last NaN
-            self._coords = np.vstack(lst)[:-1, :]
+                coords = [c for poly in polys for c in (poly.exterior.coords, nan)]
+                coords = np.vstack(coords[:-1])
+
+            # remove the very last nan and stack
+            self._coords = coords
 
         return self._coords
 

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -69,9 +69,7 @@ def test_name(test_regions):
     assert test_regions.name == name
 
 
-@pytest.mark.parametrize(
-    "test_regions, numbers", zip(all_test_regions, all_numbers, strict=True)
-)
+@pytest.mark.parametrize("test_regions, numbers", zip(all_test_regions, all_numbers))
 def test_numbers(test_regions, numbers):
     assert np.allclose(test_regions.numbers, numbers)
 
@@ -145,7 +143,7 @@ def test_centroid_multipolygon():
 
 
 @pytest.mark.parametrize(
-    "test_regions, number", zip(all_test_regions, all_first_numbers, strict=True)
+    "test_regions, number", zip(all_test_regions, all_first_numbers)
 )
 def test_map_keys_one(test_regions, number):
     pytest.raises(KeyError, test_regions1.__getitem__, "")
@@ -180,7 +178,7 @@ def test_map_keys_unique():
 
 
 @pytest.mark.parametrize(
-    "test_regions, number", zip(all_test_regions, all_first_numbers, strict=True)
+    "test_regions, number", zip(all_test_regions, all_first_numbers)
 )
 def test_subset_to_Region(test_regions, number):
     s1 = test_regions[number]
@@ -200,7 +198,7 @@ def test_subset_to_Region(test_regions, number):
 
 
 @pytest.mark.parametrize(
-    "test_regions, number", zip(all_test_regions, all_first_numbers, strict=True)
+    "test_regions, number", zip(all_test_regions, all_first_numbers)
 )
 def test_subset_to_Regions(test_regions, number):
     s1 = test_regions[[number]]

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -47,7 +47,7 @@ all_test_regions = (test_regions1, test_regions2, test_regions3, test_regions4)
 
 all_numbers = (numbers1, numbers2, numbers3, numbers4)
 
-all_first_numbers = (0, 1, 2, 0.0)
+all_first_numbers = tuple(num[0] for num in all_numbers)
 
 # =============================================================================
 
@@ -70,7 +70,7 @@ def test_name(test_regions):
 
 
 @pytest.mark.parametrize(
-    "test_regions, numbers", zip(all_test_regions, all_numbers), strict=True
+    "test_regions, numbers", zip(all_test_regions, all_numbers, strict=True)
 )
 def test_numbers(test_regions, numbers):
     assert np.allclose(test_regions.numbers, numbers)

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -180,7 +180,7 @@ def test_map_keys_unique():
 @pytest.mark.parametrize(
     "test_regions, number", zip(all_test_regions, all_first_numbers)
 )
-def test_subset_to_Region(test_regions, number):
+def test_subset_to_OneRegion(test_regions, number):
     s1 = test_regions[number]
     assert isinstance(s1, _OneRegion)
     assert s1.number == number
@@ -195,6 +195,13 @@ def test_subset_to_Region(test_regions, number):
     assert isinstance(s1, _OneRegion)
     assert s1.number == number
     assert s1.abbrev == "uSq1"
+
+
+@pytest.mark.parametrize("test_region", all_test_regions)
+def test_Regions_iter(test_region):
+
+    for result, expected in zip(test_region, test_region.regions.values()):
+        assert result is expected
 
 
 @pytest.mark.parametrize(

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -37,14 +37,17 @@ test_regions2 = Regions(poly, numbers2, names_dict, abbrevs_dict, name=name)
 numbers3 = [2, 3]
 test_regions3 = Regions(outlines, np.array(numbers3), names, abbrevs, name=name)
 
+# float numbers
+numbers4 = [0.0, 1.0]
+test_regions4 = Regions(outlines, np.array(numbers4), names, abbrevs, name=name)
 
 # =============================================================================
 
-all_test_regions = (test_regions1, test_regions2, test_regions3)
+all_test_regions = (test_regions1, test_regions2, test_regions3, test_regions4)
 
-all_numbers = (numbers1, numbers2, numbers3)
+all_numbers = (numbers1, numbers2, numbers3, numbers4)
 
-all_first_numbers = (0, 1, 2)
+all_first_numbers = (0, 1, 2, 0.0)
 
 # =============================================================================
 
@@ -66,7 +69,9 @@ def test_name(test_regions):
     assert test_regions.name == name
 
 
-@pytest.mark.parametrize("test_regions, numbers", zip(all_test_regions, all_numbers))
+@pytest.mark.parametrize(
+    "test_regions, numbers", zip(all_test_regions, all_numbers), strict=True
+)
 def test_numbers(test_regions, numbers):
     assert np.allclose(test_regions.numbers, numbers)
 
@@ -140,7 +145,7 @@ def test_centroid_multipolygon():
 
 
 @pytest.mark.parametrize(
-    "test_regions, number", zip(all_test_regions, all_first_numbers)
+    "test_regions, number", zip(all_test_regions, all_first_numbers, strict=True)
 )
 def test_map_keys_one(test_regions, number):
     pytest.raises(KeyError, test_regions1.__getitem__, "")
@@ -175,7 +180,7 @@ def test_map_keys_unique():
 
 
 @pytest.mark.parametrize(
-    "test_regions, number", zip(all_test_regions, all_first_numbers)
+    "test_regions, number", zip(all_test_regions, all_first_numbers, strict=True)
 )
 def test_subset_to_Region(test_regions, number):
     s1 = test_regions[number]
@@ -195,7 +200,7 @@ def test_subset_to_Region(test_regions, number):
 
 
 @pytest.mark.parametrize(
-    "test_regions, number", zip(all_test_regions, all_first_numbers)
+    "test_regions, number", zip(all_test_regions, all_first_numbers, strict=True)
 )
 def test_subset_to_Regions(test_regions, number):
     s1 = test_regions[[number]]

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -61,6 +61,15 @@ r2 = Regions(name=name, numbers=numbers, names=names, abbrevs=abbrevs, outlines=
 multipoly = MultiPolygon([poly1, poly2])
 r3 = Regions([multipoly])
 
+# float numbers
+r4 = Regions(
+    outlines,
+    numbers=[
+        0.0,
+        1,
+    ],
+)
+
 # a region with segments longer than 1, use Polygon to close the coords
 r_large = regionmask.Regions([Polygon(c * 10) for c in r1.coords])
 
@@ -270,6 +279,22 @@ def test_plot_regions_projection():
 def test_plot_lines(plotfunc):
 
     func = getattr(r1, plotfunc)
+
+    with figure_context():
+        ax = func(tolerance=None)
+
+        lines = ax.collections[0].get_segments()
+
+        assert len(lines) == 2
+        assert np.allclose(lines[0], outl1_closed)
+        assert np.allclose(lines[1], outl2_closed)
+
+
+@requires_matplotlib
+@pytest.mark.parametrize("plotfunc", PLOTFUNCS)
+def test_plot_lines_float_numbers(plotfunc):
+
+    func = getattr(r4, plotfunc)
 
     with figure_context():
         ax = func(tolerance=None)

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -62,13 +62,7 @@ multipoly = MultiPolygon([poly1, poly2])
 r3 = Regions([multipoly])
 
 # float numbers
-r4 = Regions(
-    outlines,
-    numbers=[
-        0.0,
-        1,
-    ],
-)
+r4 = Regions(outlines, numbers=[0.0, 1.0])
 
 # a region with segments longer than 1, use Polygon to close the coords
 r_large = regionmask.Regions([Polygon(c * 10) for c in r1.coords])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Towards #471
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

I found that float indices do not work currently. This allows them. I am not 100% sure that is the best idea, and if they should not be cast to int instead. Bet let's do this for now. In doing so, I found that there several optimizations that are possible.

This will need #477 and #477 will need this to pass - oh well