### PR TITLE
removed natural_earth defined_region (cartopy)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 
 - Removed support for Python 3.8 (:pull:`465`).
+- Removed the ``regionmask.defined_regions.natural_earth`` regions which were deprecated
+  in v0.9.0 (:pull:`479`)
 - Removed the deprecated ``subsample`` keyword from the plotting methods (:pull:`468`).
 - Removed the deprecated ``_ar6_pre_revisions`` regions (:pull:`#466`).
 

--- a/regionmask/defined_regions/__init__.py
+++ b/regionmask/defined_regions/__init__.py
@@ -2,7 +2,21 @@
 
 from . import _natural_earth, _ressources
 from ._ar6 import ar6
-from ._natural_earth import natural_earth, natural_earth_v4_1_0, natural_earth_v5_0_0
+from ._natural_earth import natural_earth_v4_1_0, natural_earth_v5_0_0
 from .giorgi import giorgi
 from .prudence import prudence
 from .srex import srex
+
+
+def __getattr__(attr_name):
+    # TODO: remove in v0.14.0 or so (added in v0.12.0)
+
+    if attr_name == "natural_earth":
+        raise AttributeError(
+            "The `natural_earth` regions have been removed. Use ``natural_earth_v4_1_0`` "
+            " or ``natural_earth_v5_0_0`` instead."
+        )
+
+    raise AttributeError(
+        f"module 'regionmask.defined_regions' has no attribute '{attr_name}'"
+    )

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -1,6 +1,3 @@
-import os
-import warnings
-from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
 
@@ -19,13 +16,6 @@ try:
     engine = "pyogrio"
 except ImportError:
     engine = "fiona"
-
-# TODO: remove deprecated (v0.9.0) natural_earth class and instance & clean up
-
-ALTERNATIVE = (
-    "Please use ``regionmask.defined_regions.natural_earth_v4_1_0`` or "
-    "``regionmask.defined_regions.natural_earth_v5_0_0`` instead"
-)
 
 
 def _maybe_get_column(df, colname):
@@ -208,7 +198,7 @@ _ocean_basins_50 = _NaturalEarthFeature(
 )
 
 
-class NaturalEarth(ABC):
+class NaturalEarth:
     """class combining all natural_earth features/ geometries
 
     Because data must be downloaded, we organise it as a class so that
@@ -230,9 +220,9 @@ class NaturalEarth(ABC):
 
         self._ocean_basins_50 = None
 
-    @abstractmethod
     def _obtain_ne(self, natural_earth_feature, **kwargs):
-        ...
+        shapefilename = natural_earth_feature.shapefilename(self.version)
+        return _obtain_ne(shapefilename, **kwargs)
 
     @property
     def countries_110(self):
@@ -355,67 +345,7 @@ class NaturalEarth(ABC):
         return "Region Definitions from 'http://www.naturalearthdata.com'."
 
 
-def _fix_ocean_basins_50_cartopy(self, df):
-    """ocean basins 50 has duplicate entries"""
-
-    names_v4_1_0 = {
-        14: "Mediterranean Sea",
-        30: "Mediterranean Sea",
-        26: "Ross Sea",
-        29: "Ross Sea",
-    }
-
-    names_v5_0_0 = {
-        74: "Great Barrier Reef",
-        114: "Great Barrier Reef",
-    }
-
-    names_v5_1_2 = {
-        74: "Great Barrier Reef",
-        113: "Great Barrier Reef",
-    }
-
-    is_v4_1_0 = all(df.loc[idx]["name"] == name for idx, name in names_v4_1_0.items())
-    is_v5_0_0 = all(df.loc[idx]["name"] == name for idx, name in names_v5_0_0.items())
-    is_v5_1_2 = all(df.loc[idx]["name"] == name for idx, name in names_v5_1_2.items())
-
-    if is_v4_1_0:
-        df = _fix_ocean_basins_50_v4_1_0(self, df)
-    elif is_v5_0_0:
-        df = _fix_ocean_basins_50_v5_0_0(self, df)
-    elif is_v5_1_2:
-        df = _fix_ocean_basins_50_v5_1_2(self, df)
-    else:
-        raise ValueError(
-            "Unknown version of the ocean basins 50m data from naturalearth. "
-            f"{ALTERNATIVE}."
-        )
-
-    return df
-
-
-def _fix_ocean_basins_50_v4_1_0(self, df):
-    """fix ocean basins 50 for naturalearth v4.1.0
-
-    - Mediterranean Sea and Ross Sea have two parts: renamed to Eastern and Western
-      Basin
-    """
-
-    new_names = {
-        14: "Mediterranean Sea Eastern Basin",
-        30: "Mediterranean Sea Western Basin",
-        26: "Ross Sea Eastern Basin",
-        29: "Ross Sea Western Basin",
-    }
-
-    # rename duplicated regions
-    for idx, new_name in new_names.items():
-        df.loc[idx, "name"] = new_name
-
-    return df
-
-
-def _unify__great_barrier_reef(df, idx1, idx2):
+def _unify_great_barrier_reef(df, idx1, idx2):
 
     p1 = df.loc[idx1].geometry
     p2 = df.loc[idx2].geometry
@@ -429,103 +359,50 @@ def _unify__great_barrier_reef(df, idx1, idx2):
     return df
 
 
-def _fix_ocean_basins_50_v5_0_0(self, df):
-    """fix ocean basins 50 for naturalearth v5.0.0
-
-    - Mediterranean Sea and Ross Sea is **no longer** split in two.
-    - There are two regions named Great Barrier Reef - these are now merged
-    - The numbers/ indices are different from Version 4.0!
-    """
-
-    return _unify__great_barrier_reef(df, 74, 114)
-
-
-def _fix_ocean_basins_50_v5_1_2(self, df):
-    """fix ocean basins 50 for naturalearth v5.1.2
-
-    - Sea of Japan & Korea Strait geometries are different
-    - the rest (including the split of the Great Barrier Reef) is as in v5.0.0
-    - but the regions are ordered different
-    """
-
-    return _unify__great_barrier_reef(df, 74, 113)
-
-
-class NaturalEarthCartopy(NaturalEarth):
-
-    _fix_ocean_basins_50 = _fix_ocean_basins_50_cartopy
-
-    def _obtain_ne(self, natural_earth_feature, **kwargs):
-
-        shapefilename = _get_shapefilename_cartopy(
-            natural_earth_feature.resolution,
-            natural_earth_feature.category,
-            natural_earth_feature.name,
-        )
-
-        return _obtain_ne(shapefilename, **kwargs)
-
-
 class NaturalEarth_v4_1_0(NaturalEarth):
 
-    _fix_ocean_basins_50 = _fix_ocean_basins_50_v4_1_0
     version = "v4.1.0"
 
-    def _obtain_ne(self, natural_earth_feature, **kwargs):
-        shapefilename = natural_earth_feature.shapefilename(self.version)
-        return _obtain_ne(shapefilename, **kwargs)
+    @staticmethod
+    def _fix_ocean_basins_50(df):
+        """fix ocean basins 50 for naturalearth v4.1.0
+
+        - Mediterranean Sea and Ross Sea have two parts: renamed to Eastern and Western
+        Basin
+        """
+
+        new_names = {
+            14: "Mediterranean Sea Eastern Basin",
+            30: "Mediterranean Sea Western Basin",
+            26: "Ross Sea Eastern Basin",
+            29: "Ross Sea Western Basin",
+        }
+
+        # rename duplicated regions
+        for idx, new_name in new_names.items():
+            df.loc[idx, "name"] = new_name
+
+        return df
 
 
 class NaturalEarth_v5_0_0(NaturalEarth):
 
-    _fix_ocean_basins_50 = _fix_ocean_basins_50_v5_0_0
     version = "v5.0.0"
 
-    def _obtain_ne(self, natural_earth_feature, **kwargs):
-        shapefilename = natural_earth_feature.shapefilename(self.version)
-        return _obtain_ne(shapefilename, **kwargs)
+    @staticmethod
+    def _fix_ocean_basins_50(df):
+        """fix ocean basins 50 for naturalearth v5.0.0
 
+        - Mediterranean Sea and Ross Sea is **no longer** split in two.
+        - There are two regions named Great Barrier Reef - these are now merged
+        - The numbers/ indices are different from Version 4.0!
+        """
 
-natural_earth = NaturalEarthCartopy()
+        return _unify_great_barrier_reef(df, 74, 114)
+
 
 natural_earth_v4_1_0 = NaturalEarth_v4_1_0()
 natural_earth_v5_0_0 = NaturalEarth_v5_0_0()
-
-
-def _get_shapefilename_cartopy(resolution, category, name):
-
-    try:
-        import cartopy
-    except ImportError as e:
-        msg = (
-            "``regionmask.defined_regions.natural_earth`` requires cartopy and is "
-            f"deprecated.\n{ALTERNATIVE} (which do not require cartopy)."
-        )
-        raise ImportError(msg) from e
-
-    _cartopy_data_dir = cartopy.config["data_dir"]
-
-    # check if cartopy has already downloaded the file
-    cartopy_file = os.path.join(
-        _cartopy_data_dir,
-        "shapefiles",
-        "natural_earth",
-        f"{category}",
-        f"ne_{resolution}_{name}.shp",
-    )
-
-    if not os.path.exists(cartopy_file):
-        raise ValueError(
-            "``regionmask.defined_regions.natural_earth`` is deprecated. Will not "
-            f"download new files via this interface. {ALTERNATIVE}."
-        )
-
-    warnings.warn(
-        f"``regionmask.defined_regions.natural_earth`` is deprecated. {ALTERNATIVE}.",
-        FutureWarning,
-    )
-
-    return cartopy_file
 
 
 @contextmanager

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -205,7 +205,9 @@ class NaturalEarth:
     we only download it on demand.
     """
 
-    def __init__(self):
+    def __init__(self, version, fix_ocean_basins_50):
+        self.version = version
+        self._fix_ocean_basins_50 = fix_ocean_basins_50
 
         self._countries_110 = None
         self._countries_50 = None
@@ -342,7 +344,7 @@ class NaturalEarth:
         return self._ocean_basins_50
 
     def __repr__(self):
-        return "Region Definitions from 'http://www.naturalearthdata.com'."
+        return f"Region definitions from 'http://www.naturalearthdata.com' - {self.version}"
 
 
 def _unify_great_barrier_reef(df, idx1, idx2):
@@ -359,50 +361,40 @@ def _unify_great_barrier_reef(df, idx1, idx2):
     return df
 
 
-class NaturalEarth_v4_1_0(NaturalEarth):
+def _fix_ocean_basins_50_v4_1_0(df):
+    """fix ocean basins 50 for naturalearth v4.1.0
 
-    version = "v4.1.0"
+    - Mediterranean Sea and Ross Sea have two parts: renamed to Eastern and Western
+    Basin
+    """
 
-    @staticmethod
-    def _fix_ocean_basins_50(df):
-        """fix ocean basins 50 for naturalearth v4.1.0
+    new_names = {
+        14: "Mediterranean Sea Eastern Basin",
+        30: "Mediterranean Sea Western Basin",
+        26: "Ross Sea Eastern Basin",
+        29: "Ross Sea Western Basin",
+    }
 
-        - Mediterranean Sea and Ross Sea have two parts: renamed to Eastern and Western
-        Basin
-        """
+    # rename duplicated regions
+    for idx, new_name in new_names.items():
+        df.loc[idx, "name"] = new_name
 
-        new_names = {
-            14: "Mediterranean Sea Eastern Basin",
-            30: "Mediterranean Sea Western Basin",
-            26: "Ross Sea Eastern Basin",
-            29: "Ross Sea Western Basin",
-        }
-
-        # rename duplicated regions
-        for idx, new_name in new_names.items():
-            df.loc[idx, "name"] = new_name
-
-        return df
+    return df
 
 
-class NaturalEarth_v5_0_0(NaturalEarth):
+def _fix_ocean_basins_50_v5_0_0(df):
+    """fix ocean basins 50 for naturalearth v5.0.0
 
-    version = "v5.0.0"
+    - Mediterranean Sea and Ross Sea is **no longer** split in two.
+    - There are two regions named Great Barrier Reef - these are now merged
+    - The numbers/ indices are different from Version 4.0!
+    """
 
-    @staticmethod
-    def _fix_ocean_basins_50(df):
-        """fix ocean basins 50 for naturalearth v5.0.0
-
-        - Mediterranean Sea and Ross Sea is **no longer** split in two.
-        - There are two regions named Great Barrier Reef - these are now merged
-        - The numbers/ indices are different from Version 4.0!
-        """
-
-        return _unify_great_barrier_reef(df, 74, 114)
+    return _unify_great_barrier_reef(df, 74, 114)
 
 
-natural_earth_v4_1_0 = NaturalEarth_v4_1_0()
-natural_earth_v5_0_0 = NaturalEarth_v5_0_0()
+natural_earth_v4_1_0 = NaturalEarth("v4.1.0", _fix_ocean_basins_50_v4_1_0)
+natural_earth_v5_0_0 = NaturalEarth("v5.0.0", _fix_ocean_basins_50_v5_0_0)
 
 
 @contextmanager

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from regionmask import Regions, defined_regions
-from regionmask.defined_regions._natural_earth import _maybe_get_column
+from regionmask.defined_regions._natural_earth import NaturalEarth, _maybe_get_column
 
 from . import requires_cartopy
 from .utils import REGIONS_ALL
@@ -49,8 +49,24 @@ def test_defined_regions_attribute_error():
         defined_regions.attr
 
 
-def test_fix_ocean_basins_50():
+def test_natural_earth_wrong_version():
+    ne_wrong_version = NaturalEarth("v0.3.0", None)
 
+    with pytest.raises(ValueError, match="version must"):
+        ne_wrong_version.land_110
+
+
+def test_natural_earth_repr():
+    actual = repr(defined_regions.natural_earth_v4_1_0)
+    expected = "Region definitions from 'http://www.naturalearthdata.com' - v4.1.0"
+    assert actual == expected
+
+    actual = repr(defined_regions.natural_earth_v5_0_0)
+    expected = "Region definitions from 'http://www.naturalearthdata.com' - v5.0.0"
+    assert actual == expected
+
+
+def test_fix_ocean_basins_50():
     region = defined_regions.natural_earth_v4_1_0.ocean_basins_50
     assert "Mediterranean Sea Eastern Basin" in region.names
     assert "Ross Sea Eastern Basin" in region.names

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -1,4 +1,3 @@
-import os
 from operator import attrgetter
 
 import numpy as np
@@ -7,12 +6,8 @@ import pytest
 from regionmask import Regions, defined_regions
 from regionmask.defined_regions._natural_earth import _maybe_get_column
 
-from . import has_cartopy, requires_cartopy
-from .utils import (
-    REGIONS_ALL,
-    REGIONS_REQUIRING_CARTOPY,
-    download_naturalearth_region_or_skip,
-)
+from . import requires_cartopy
+from .utils import REGIONS_ALL
 
 
 def _test_region(defined_region):
@@ -37,49 +32,21 @@ def test_defined_region(defined_region):
     _test_region(defined_region)
 
 
-@requires_cartopy
-@pytest.mark.filterwarnings("ignore:Downloading")
-@pytest.mark.parametrize("defined_region", REGIONS_REQUIRING_CARTOPY, ids=str)
-def test_defined_regions_natural_earth(monkeypatch, defined_region):
-    # TODO: remove this test once defined_regions.natural_earth is removed
+def test_defined_regions_natural_earth_informative_error():
 
-    import cartopy
+    with pytest.raises(
+        AttributeError, match="The `natural_earth` regions have been removed."
+    ):
+        defined_regions.natural_earth
 
-    from regionmask.defined_regions import _natural_earth
 
-    match = "``regionmask.defined_regions.natural_earth`` is deprecated"
+def test_defined_regions_attribute_error():
 
-    # get regionmask.defined_regions._natural_earth._land_10 dataclass
-    region = defined_region.region_name.split(".")[1]
-    natural_earth_feature = attrgetter(f"_{region}")(_natural_earth)
-
-    # get the filename of cartopy-downloaded shapefiles
-    resolution = natural_earth_feature.resolution
-    category = natural_earth_feature.category
-    name = natural_earth_feature.name
-
-    _cartopy_data_dir = cartopy.config["data_dir"]
-
-    # check if cartopy has already downloaded the file
-    cartopy_file = os.path.join(
-        _cartopy_data_dir,
-        "shapefiles",
-        "natural_earth",
-        f"{category}",
-        f"ne_{resolution}_{name}.shp",
-    )
-
-    # only raise an error if the file is not downloaded
-    if not os.path.isfile(cartopy_file):
-        with pytest.raises(ValueError, match=match):
-            attrgetter(defined_region.region_name)(defined_regions)
-
-    # download data using cartopy
-    download_naturalearth_region_or_skip(monkeypatch, natural_earth_feature)
-
-    # get region and ensure deprcation warning is raised
-    with pytest.warns(FutureWarning, match=match):
-        _test_region(defined_region)
+    with pytest.raises(
+        AttributeError,
+        match="module 'regionmask.defined_regions' has no attribute 'attr'",
+    ):
+        defined_regions.attr
 
 
 def test_fix_ocean_basins_50():
@@ -119,10 +86,3 @@ def test_maybe_get_column():
 
     with pytest.raises(KeyError, match="not on the geopandas dataframe"):
         _maybe_get_column(lowercase, "not_a_column")
-
-
-@pytest.mark.skipif(has_cartopy, reason="should run if cartopy is _not_ installed")
-def test_natural_earth_raises_without_cartopy():
-
-    with pytest.raises(ImportError, match="requires cartopy"):
-        defined_regions.natural_earth.countries_110

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -1,10 +1,7 @@
-import warnings
 from dataclasses import dataclass
-from functools import partial
 from typing import Optional
 
 import numpy as np
-import pytest
 import xarray as xr
 
 from regionmask import Regions
@@ -157,36 +154,3 @@ REGIONS += _REGIONS_NATURAL_EARTH_v5_0_0
 
 REGIONS_ALL = REGIONS.copy()
 REGIONS_ALL += _REGIONS_NATURAL_EARTH_v4_1_0
-
-REGIONS_REQUIRING_CARTOPY = [
-    DefinedRegion("natural_earth.countries_110", 177),
-    DefinedRegion("natural_earth.countries_50", 242),
-    DefinedRegion("natural_earth.us_states_50", 51),
-    DefinedRegion("natural_earth.us_states_10", 51),
-    DefinedRegion("natural_earth.land_110", 1),
-    DefinedRegion("natural_earth.land_50", 1),
-    DefinedRegion("natural_earth.land_10", 1),
-    DefinedRegion("natural_earth.ocean_basins_50", 117),
-]
-
-
-def download_naturalearth_region_or_skip(monkeypatch, natural_earth_feature):
-
-    from urllib.request import URLError, urlopen
-
-    import cartopy
-    from cartopy.io import shapereader
-
-    # add a timeout to cartopy.io.urlopen else it can run indefinitely
-    monkeypatch.setattr(cartopy.io, "urlopen", partial(urlopen, timeout=5))
-
-    try:
-        shapereader.natural_earth(
-            natural_earth_feature.resolution,
-            natural_earth_feature.category,
-            natural_earth_feature.name,
-        )
-    except URLError as e:
-        warnings.warn(str(e))
-        warnings.warn("naturalearth download timeout - test not run!")
-        pytest.skip()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Towards  #471
 - [x] In preparation for #357
 - [x] In preparation for #410
 - [x] Tests removed
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

I wanted to wait with removing `regionmask.defined_regions.natural_earth` because this was used widely. Hoever, to fix #410 I want to add the 5.1.2 natural earth version and don't want to do this with the old stuff around. So I raise an informative `AttributeError` instead. Allows to remove a lot specal case code, which is always nice.
