### PR TITLE
deprecate Regions.coords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,16 +16,14 @@ v0.12.0 (unreleased)
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
+- Deprecated ``Regions.coords`` because they are no longer used (:pull:`486`).
 - Removed support for Python 3.8 (:pull:`465`).
 - Removed the ``regionmask.defined_regions.natural_earth`` regions which were deprecated
-  in v0.9.0 (:pull:`479`)
+  in v0.9.0,  (:pull:`479`)
 - Removed the deprecated ``subsample`` keyword from the plotting methods (:pull:`468`).
-- Removed the deprecated ``_ar6_pre_revisions`` regions (:pull:`#466`).
+- Removed the deprecated ``_ar6_pre_revisions`` regions (:pull:`466`).
 
 Enhancements
-~~~~~~~~~~~~
-
-Deprecations
 ~~~~~~~~~~~~
 
 New regions

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -4,6 +4,7 @@
 # Date:
 
 import copy
+import warnings
 
 import geopandas as gp
 import numpy as np
@@ -242,6 +243,13 @@ class Regions:
 
     @property
     def coords(self):
+        warnings.warn(
+            "`Regions.coords` has been deprecated in v0.12.0 and will be removed. "
+            "Please raise an issue if you have an use case for them.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         """list of coordinates of the region vertices as numpy array"""
         return [r.coords for r in self.regions.values()]
 

--- a/regionmask/tests/test_Regions.py
+++ b/regionmask/tests/test_Regions.py
@@ -84,6 +84,13 @@ def test_abbrevs(test_regions):
     assert test_regions.abbrevs == ["uSq1", "uSq2"]
 
 
+def test_coords_deprecated():
+
+    with pytest.warns(FutureWarning, match="`Regions.coords` has been deprecated"):
+        test_regions1.coords
+
+
+@pytest.mark.filterwarnings("ignore:`Regions.coords` has been deprecated")
 def test_coords():
     # passing numpy coords does not automatically close the coords
     assert np.allclose(test_regions1.coords, [outl1, outl2])

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -86,7 +86,7 @@ def test_mask_wrong_number_fill(func):
         )
 
     with pytest.raises(ValueError, match="`numbers` and `coords` must have"):
-        func(dummy_ds.lon, dummy_ds.lat, dummy_region.coords, numbers=[5])
+        func(dummy_ds.lon, dummy_ds.lat, dummy_region.polygons, numbers=[5])
 
 
 @pytest.mark.parametrize("method", MASK_METHODS)

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -65,7 +65,8 @@ r3 = Regions([multipoly])
 r4 = Regions(outlines, numbers=[0.0, 1.0])
 
 # a region with segments longer than 1, use Polygon to close the coords
-r_large = regionmask.Regions([Polygon(c * 10) for c in r1.coords])
+_p = [Polygon(np.array(c.exterior.coords) * 10) for c in r1.polygons]
+r_large = regionmask.Regions(_p)
 
 # create a polygon with a hole
 interior1_closed = ((0.2, 0.2), (0.2, 0.45), (0.45, 0.45), (0.45, 0.2), (0.2, 0.2))
@@ -372,8 +373,12 @@ def test_plot_lines_tolerance_None(plotfunc):
         ax = func(tolerance=None)
         lines = ax.collections[0].get_paths()
 
-        np.testing.assert_allclose(lines[0].vertices, r_large.coords[0])
-        np.testing.assert_allclose(lines[1].vertices, r_large.coords[1])
+        np.testing.assert_allclose(
+            lines[0].vertices, r_large.polygons[0].exterior.coords
+        )
+        np.testing.assert_allclose(
+            lines[1].vertices, r_large.polygons[1].exterior.coords
+        )
 
 
 @requires_matplotlib
@@ -421,7 +426,7 @@ def test_plot_lines_from_poly(plotfunc):
         lines = ax.collections[0].get_segments()
 
         assert len(lines) == 2
-        assert np.allclose(lines[0], r2.coords[0])
+        assert np.allclose(lines[0], r2.polygons[0].exterior.coords)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #277
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
