### PR TITLE
fix_regions not extending to 180°E/ 90°S, add natural_earth_v5_1_2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,10 +29,23 @@ Enhancements
 New regions
 ~~~~~~~~~~~
 
+- Added newest version of natural earth regions: ``natural_earth_v5_1_2`` - see also bug fixes
+  (:issue:`357`, :pull:`488`).
+
 Bug Fixes
 ~~~~~~~~~
 
 - Fixed the default value of ``overlap`` of :py:func:`from_geopandas` to ``None`` (:issue:`453`, :pull:`470`).
+- Fixed some numerical issues for natural earth regions for ``natural_earth_v5_1_2``:
+
+   - ``ocean_basins_50`` not extending to 180°E  (:issue:`410`, :pull:`488`).
+   - ``countries_50`` and ``land_50`` not extending to -90° N (:issue:`487`, :pull:`488`).
+
+     .. warning::
+        The three regions (``ocean_basins_50``, ``countries_50``, and ``land_50``) are
+        not corrected for ``natural_earth_v4_0_0`` and ``natural_earth_v5_0_0``.
+        It is therefore recommended to use ``natural_earth_v5_1_2``.
+
 
 Docs
 ~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,8 @@ Bug Fixes
      .. warning::
         The three regions (``ocean_basins_50``, ``countries_50``, and ``land_50``) are
         not corrected for ``natural_earth_v4_0_0`` and ``natural_earth_v5_0_0``.
-        It is therefore recommended to use ``natural_earth_v5_1_2``.
+        It is therefore recommended to use ``natural_earth_v5_1_2`` for these
+        regions.
 
 
 Docs

--- a/docs/defined_countries.rst
+++ b/docs/defined_countries.rst
@@ -12,13 +12,6 @@ The following countries and regions are defined in regionmask.
 * US States 1:50m
 * US States 1:10m
 
-.. warning::
-   ``regionmask.defined_regions.natural_earth`` is deprecated.
-   Please use ``natural_earth_v4_1_0`` or ``natural_earth_v5_0_0`` instead.
-
-   Be careful when working with the different versions of NaturalEarth regions. Some
-   polygons and regions have changed and the numbering of the regions may be different.
-
 .. note::
    A mask obtained with a fine resolution dataset is not necessarily better.
    Always check your mask!
@@ -39,6 +32,16 @@ Import regionmask:
 
 Countries
 =========
+
+.. warning::
+   ``natural_earth_v4_1_0.countries_50`` and ``natural_earth_v5_0_0.countries_50``
+   do not extend all the way to 90°S (see `#487 <https://github.com/regionmask/regionmask/issues/487>`_).
+   If Antarctica is of interest, please use ``natural_earth_v5_1_2.countries_50`` instead.
+
+   Be careful, however, as the regions may have changed between the natural_earth versions.
+
+   Note that ``countries_10`` and ``countries_110`` do not exhibit this problem.
+
 
 .. ipython:: python
 

--- a/docs/defined_landmask.rst
+++ b/docs/defined_landmask.rst
@@ -10,14 +10,6 @@ The following landmasks are currently available:
 * Land 1:50m
 * Land 1:10m
 
-.. warning::
-   ``regionmask.defined_regions.natural_earth`` is deprecated.
-   Please use ``natural_earth_v4_1_0`` or ``natural_earth_v5_0_0`` instead.
-
-   Be careful when working with the different versions of NaturalEarth regions. Some
-   polygons and regions have changed and the numbering of the regions may be different.
-
-
 .. note::
    If available, it is better to use the landmask of the used data set.
 
@@ -37,6 +29,16 @@ Import regionmask:
 
 Landmask
 ========
+
+.. warning::
+   ``natural_earth_v4_1_0.land_50`` and ``natural_earth_v5_0_0.land_50``
+   do not extend all the way to 90°S (see `#487 <https://github.com/regionmask/regionmask/issues/487>`_).
+   If Antarctica is of interest, please use ``natural_earth_v5_1_2.land_50`` instead.
+
+   Be careful, however, as the regions may have changed between the natural_earth versions.
+
+   Note that ``land_10`` and ``land_110`` do not exhibit this problem.
+
 
 .. ipython:: python
 

--- a/docs/defined_ocean_basins.rst
+++ b/docs/defined_ocean_basins.rst
@@ -6,15 +6,8 @@ The outline of the marine areas are obtained from
 They are automatically downloaded, cached\ [#]_ and opened with geopandas.
 The following marine regions are defined in regionmask:
 
-* Marine Areas 1:50m
+* Ocean basins 1:50m
 
-
-.. warning::
-   ``regionmask.defined_regions.natural_earth`` is deprecated.
-   Please use ``natural_earth_v4_1_0`` or ``natural_earth_v5_0_0`` instead.
-
-   Be careful when working with the different versions of NaturalEarth regions. Some
-   polygons and regions have changed and the numbering of the regions may be different.
 
 .. ipython:: python
     :suppress:
@@ -33,9 +26,17 @@ Import regionmask:
 Ocean Basins
 ============
 
+.. warning::
+   ``natural_earth_v4_1_0.ocean_basins_50`` and ``natural_earth_v5_0_0.ocean_basins_50``
+   do not extend all the way to 180°E (see `#410 <https://github.com/regionmask/regionmask/issues/410>`_).
+   Please use ``natural_earth_v5_1_2.ocean_basins_50``
+
+   Be careful, however, as the regions changed between the natural_earth versions.
+
+
 .. ipython:: python
 
-    basins = regionmask.defined_regions.natural_earth_v5_0_0.ocean_basins_50
+    basins = regionmask.defined_regions.natural_earth_v5_1_2.ocean_basins_50
     basins
 
 .. ipython:: python

--- a/regionmask/core/utils.py
+++ b/regionmask/core/utils.py
@@ -282,3 +282,76 @@ def flatten_3D_mask(mask_3D):
 
     # mask all gridpoints not belonging to any region
     return mask_2D.where(mask_3D.any("region"))
+
+
+def _snap_polygon(polygon, to, atol, xy_col):
+    """
+
+    idx: x or y coordinate
+    - 0: x-coord
+    - 1: y-coord
+
+    """
+
+    arr = shapely.get_coordinates(polygon)
+
+    sel = np.isclose(arr[:, xy_col], to, atol=atol)
+    arr[sel, xy_col] = to
+
+    return shapely.set_coordinates(polygon, arr)
+
+
+def _snap_polygon_shapely_18(polygon, to, atol, xy_col):
+
+    import shapely.ops
+
+    def _snap_x(x, y, z=None):
+
+        x = np.array(x)
+        sel = np.isclose(x, to, atol=atol)
+        x[sel] = to
+        x = x.tolist()
+        return tuple(filter(None, [x, y, z]))
+
+    def _snap_y(x, y, z=None):
+
+        y = np.array(y)
+        sel = np.isclose(y, to, atol=atol)
+
+        y[sel] = to
+        y = y.tolist()
+        return tuple(filter(None, [x, y, z]))
+
+    _snap_func = _snap_x if xy_col == 0 else _snap_y
+
+    polygon = shapely.ops.transform(_snap_func, polygon)
+
+    return polygon
+
+
+def _snap(df, idx, to, atol, xy_col):
+
+    polygons = df.loc[idx].geometry.tolist()
+
+    if Version(shapely.__version__) > Version("2.0.0"):
+        polygons = [_snap_polygon(poly, to, atol, xy_col) for poly in polygons]
+        df.loc[idx, "geometry"] = polygons
+
+        return df
+
+    polygons = [_snap_polygon_shapely_18(poly, to, atol, xy_col) for poly in polygons]
+
+    for i, polygon in zip(idx, polygons):
+        df.at[i, "geometry"] = polygon
+
+    return df
+
+
+def _snap_to_90S(df, idx, atol):
+
+    return _snap(df, idx, to=-90, atol=atol, xy_col=1)
+
+
+def _snap_to_180E(df, idx, atol):
+
+    return _snap(df, idx, to=180, atol=atol, xy_col=0)

--- a/regionmask/defined_regions/__init__.py
+++ b/regionmask/defined_regions/__init__.py
@@ -2,7 +2,11 @@
 
 from . import _natural_earth, _ressources
 from ._ar6 import ar6
-from ._natural_earth import natural_earth_v4_1_0, natural_earth_v5_0_0
+from ._natural_earth import (
+    natural_earth_v4_1_0,
+    natural_earth_v5_0_0,
+    natural_earth_v5_1_2,
+)
 from .giorgi import giorgi
 from .prudence import prudence
 from .srex import srex

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -6,6 +6,7 @@ from functools import cache
 import geopandas
 import numpy as np
 import pooch
+from packaging.version import Version
 from shapely.geometry import MultiPolygon
 
 from regionmask.defined_regions._ressources import _get_cache_dir
@@ -349,12 +350,50 @@ def _snap_polygon(polygon, to, atol, xy_col):
     return shapely.set_coordinates(polygon, arr)
 
 
+def _snap_polygon_shapely_18(polygon, to, atol, xy_col):
+
+    import shapely.ops
+
+    def _snap_x(x, y, z=None):
+
+        x = np.array(x)
+        sel = np.isclose(x, to, atol=atol)
+        x[sel] = to
+        x = x.tolist()
+        return tuple(filter(None, [x, y, z]))
+
+    def _snap_y(x, y, z=None):
+
+        y = np.array(y)
+        sel = np.isclose(y, to, atol=atol)
+
+        y[sel] = to
+        y = y.tolist()
+        return tuple(filter(None, [x, y, z]))
+
+    _snap_func = _snap_x if xy_col == 0 else _snap_y
+
+    polygon = shapely.ops.transform(_snap_func, polygon)
+
+    return polygon
+
+
 def _snap(df, idx, to, atol, xy_col):
+
+    import shapely
 
     polygons = df.loc[idx].geometry.tolist()
 
-    polygons = [_snap_polygon(poly, to, atol, xy_col) for poly in polygons]
-    df.loc[idx, "geometry"] = polygons
+    if Version(shapely.__version__) > Version("2.0.0"):
+        polygons = [_snap_polygon(poly, to, atol, xy_col) for poly in polygons]
+        df.loc[idx, "geometry"] = polygons
+
+        return df
+
+    polygons = [_snap_polygon_shapely_18(poly, to, atol, xy_col) for poly in polygons]
+
+    for i, polygon in zip(idx, polygons):
+        df.at[i, "geometry"] = polygon
 
     return df
 

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -23,7 +23,14 @@ def _test_region(defined_region):
     assert region.lon_180
 
     if defined_region.bounds is not None:
-        np.testing.assert_allclose(defined_region.bounds, region.bounds_global)
+
+        bound_names = ("min_lon", "min_lat", "max_lon", "max_lat")
+        bounds = {name: bnd for name, bnd in zip(bound_names, region.bounds_global)}
+
+        for name, expected in defined_region.bounds.items():
+            actual = bounds[name]
+
+            np.testing.assert_allclose(actual, expected, err_msg=name)
 
 
 @pytest.mark.parametrize("defined_region", REGIONS_ALL, ids=str)

--- a/regionmask/tests/test_defined_regions.py
+++ b/regionmask/tests/test_defined_regions.py
@@ -12,7 +12,12 @@ from .utils import REGIONS_ALL
 
 def _test_region(defined_region):
 
-    region = attrgetter(defined_region.region_name)(defined_regions)
+    # NOTE: can fail if the test order is randomized
+    if defined_region.warn_bounds:
+        with pytest.warns(UserWarning, match="does not quite extend"):
+            region = attrgetter(defined_region.region_name)(defined_regions)
+    else:
+        region = attrgetter(defined_region.region_name)(defined_regions)
 
     assert isinstance(region, Regions)
     assert len(region) == defined_region.n_regions
@@ -73,6 +78,7 @@ def test_natural_earth_repr():
     assert actual == expected
 
 
+@pytest.mark.filterwarnings("ignore:.*does not quite extend")
 def test_fix_ocean_basins_50():
     region = defined_regions.natural_earth_v4_1_0.ocean_basins_50
     assert "Mediterranean Sea Eastern Basin" in region.names
@@ -83,6 +89,7 @@ def test_fix_ocean_basins_50():
     assert "Ross Sea" in region.names
 
 
+@pytest.mark.filterwarnings("ignore:.*does not quite extend")
 @requires_cartopy
 def test_natural_earth_loaded_as_utf8():
     # GH 95

--- a/regionmask/tests/test_mask_defined_regions.py
+++ b/regionmask/tests/test_mask_defined_regions.py
@@ -37,6 +37,7 @@ def _test_mask_equal_defined_regions(region, ds, mask_method):
 
 
 @pytest.mark.filterwarnings("ignore:pygeos is deprecated")
+@pytest.mark.filterwarnings("ignore:.*does not quite extend")
 @pytest.mark.parametrize("defined_region", REGIONS, ids=str)
 @pytest.mark.parametrize("ds", DATASETS)
 def test_mask_equal_defined_regions(defined_region, ds):
@@ -45,12 +46,7 @@ def test_mask_equal_defined_regions(defined_region, ds):
         pytest.skip(reason=f"Manally skipping {defined_region.region_name}")
 
     # a loop over DATASETS is not faster - due to caching of the regions
-
-    if defined_region.warn_bounds:
-        with pytest.warns(FutureWarning, match="does not quite extend"):
-            region = attrgetter(defined_region.region_name)(defined_regions)
-    else:
-        region = attrgetter(defined_region.region_name)(defined_regions)
+    region = attrgetter(defined_region.region_name)(defined_regions)
 
     mask_method = "mask_3D" if defined_region.overlap else "mask"
     _test_mask_equal_defined_regions(region, ds, mask_method)

--- a/regionmask/tests/test_mask_defined_regions.py
+++ b/regionmask/tests/test_mask_defined_regions.py
@@ -45,6 +45,12 @@ def test_mask_equal_defined_regions(defined_region, ds):
         pytest.skip(reason=f"Manally skipping {defined_region.region_name}")
 
     # a loop over DATASETS is not faster - due to caching of the regions
-    region = attrgetter(defined_region.region_name)(defined_regions)
+
+    if defined_region.warn_bounds:
+        with pytest.warns(FutureWarning, match="does not quite extend"):
+            region = attrgetter(defined_region.region_name)(defined_regions)
+    else:
+        region = attrgetter(defined_region.region_name)(defined_regions)
+
     mask_method = "mask_3D" if defined_region.overlap else "mask"
     _test_mask_equal_defined_regions(region, ds, mask_method)

--- a/regionmask/tests/test_snap.py
+++ b/regionmask/tests/test_snap.py
@@ -1,0 +1,102 @@
+import geopandas as gpd
+import geopandas.testing
+import shapely
+
+from regionmask.core.utils import _snap, _snap_to_90S, _snap_to_180E
+
+
+def test_snap_to_180E():
+
+    poly = shapely.box(0, 0, 179, 10)
+    poly_180 = shapely.box(0, 0, 180, 10)
+
+    df = gpd.GeoDataFrame(geometry=[poly, poly])
+    expected = gpd.GeoDataFrame(geometry=[poly_180, poly])
+
+    result = _snap_to_180E(df, [0], atol=1)
+
+    geopandas.testing.assert_geodataframe_equal(result, expected)
+
+
+def test_snap_to_90S():
+
+    poly = shapely.box(0, -89.9, 180, 10)
+    poly_90 = shapely.box(0, -90, 180, 10)
+
+    df = gpd.GeoDataFrame(geometry=[poly, poly])
+    expected = gpd.GeoDataFrame(geometry=[poly, poly_90])
+
+    result = _snap_to_90S(df, [1], atol=0.1)
+
+    geopandas.testing.assert_geodataframe_equal(result, expected)
+
+
+def test_snap_coords_along():
+
+    poly = shapely.Polygon(
+        [
+            (179.0, 0.0),
+            (179.0, 2.0),
+            (179.0, 9.0),
+            (179.0, 10.0),
+            (0.0, 10.0),
+            (0.0, 0.0),
+        ]
+    )
+
+    poly_180 = shapely.Polygon(
+        [
+            (180.0, 0.0),
+            (180.0, 2.0),
+            (180.0, 9.0),
+            (180.0, 10.0),
+            (0.0, 10.0),
+            (0.0, 0.0),
+        ]
+    )
+
+    df = gpd.GeoDataFrame(geometry=[poly])
+    expected = gpd.GeoDataFrame(geometry=[poly_180])
+
+    result = _snap(df, [0], to=180, atol=1, xy_col=0)
+
+    geopandas.testing.assert_geodataframe_equal(result, expected)
+
+
+def test_snap_multipolygon():
+
+    p1 = shapely.box(0, 0, 9, 10)
+    p2 = shapely.box(0, 10, 9, 20)
+    p3 = shapely.box(-5, 0, 0, 10)
+
+    mp = shapely.MultiPolygon([p1, p2, p3])
+
+    p1_adj = shapely.box(0, 0, 10, 10)
+    p2_adj = shapely.box(0, 10, 10, 20)
+
+    mp_adj = shapely.MultiPolygon([p1_adj, p2_adj, p3])
+
+    df = gpd.GeoDataFrame(geometry=[mp])
+    expected = gpd.GeoDataFrame(geometry=[mp_adj])
+
+    result = _snap(df, [0], to=10, atol=1, xy_col=0)
+
+    geopandas.testing.assert_geodataframe_equal(result, expected)
+
+
+def test_snap_polygon_internal():
+
+    ext = [(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)]
+    hole = [(0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5)]
+
+    ext_snapped = [(0, 0), (0, 2.5), (2, 2.5), (2, 0), (0, 0)]
+
+    polygon = shapely.Polygon(ext, [hole])
+    polygon_snapped = shapely.Polygon(ext_snapped, [hole])
+
+    df = gpd.GeoDataFrame(geometry=[polygon])
+    expected = gpd.GeoDataFrame(geometry=[polygon_snapped])
+
+    result = _snap(df, [0], to=2.5, atol=0.5, xy_col=1)
+
+    geopandas.testing.assert_geodataframe_equal(result, expected)

--- a/regionmask/tests/test_snap.py
+++ b/regionmask/tests/test_snap.py
@@ -1,14 +1,15 @@
 import geopandas as gpd
 import geopandas.testing
 import shapely
+import shapely.geometry
 
 from regionmask.core.utils import _snap, _snap_to_90S, _snap_to_180E
 
 
 def test_snap_to_180E():
 
-    poly = shapely.box(0, 0, 179, 10)
-    poly_180 = shapely.box(0, 0, 180, 10)
+    poly = shapely.geometry.box(0, 0, 179, 10)
+    poly_180 = shapely.geometry.box(0, 0, 180, 10)
 
     df = gpd.GeoDataFrame(geometry=[poly, poly])
     expected = gpd.GeoDataFrame(geometry=[poly_180, poly])
@@ -20,8 +21,8 @@ def test_snap_to_180E():
 
 def test_snap_to_90S():
 
-    poly = shapely.box(0, -89.9, 180, 10)
-    poly_90 = shapely.box(0, -90, 180, 10)
+    poly = shapely.geometry.box(0, -89.9, 180, 10)
+    poly_90 = shapely.geometry.box(0, -90, 180, 10)
 
     df = gpd.GeoDataFrame(geometry=[poly, poly])
     expected = gpd.GeoDataFrame(geometry=[poly, poly_90])
@@ -33,7 +34,7 @@ def test_snap_to_90S():
 
 def test_snap_coords_along():
 
-    poly = shapely.Polygon(
+    poly = shapely.geometry.Polygon(
         [
             (179.0, 0.0),
             (179.0, 2.0),
@@ -44,7 +45,7 @@ def test_snap_coords_along():
         ]
     )
 
-    poly_180 = shapely.Polygon(
+    poly_180 = shapely.geometry.Polygon(
         [
             (180.0, 0.0),
             (180.0, 2.0),
@@ -65,16 +66,16 @@ def test_snap_coords_along():
 
 def test_snap_multipolygon():
 
-    p1 = shapely.box(0, 0, 9, 10)
-    p2 = shapely.box(0, 10, 9, 20)
-    p3 = shapely.box(-5, 0, 0, 10)
+    p1 = shapely.geometry.box(0, 0, 9, 10)
+    p2 = shapely.geometry.box(0, 10, 9, 20)
+    p3 = shapely.geometry.box(-5, 0, 0, 10)
 
-    mp = shapely.MultiPolygon([p1, p2, p3])
+    mp = shapely.geometry.MultiPolygon([p1, p2, p3])
 
-    p1_adj = shapely.box(0, 0, 10, 10)
-    p2_adj = shapely.box(0, 10, 10, 20)
+    p1_adj = shapely.geometry.box(0, 0, 10, 10)
+    p2_adj = shapely.geometry.box(0, 10, 10, 20)
 
-    mp_adj = shapely.MultiPolygon([p1_adj, p2_adj, p3])
+    mp_adj = shapely.geometry.MultiPolygon([p1_adj, p2_adj, p3])
 
     df = gpd.GeoDataFrame(geometry=[mp])
     expected = gpd.GeoDataFrame(geometry=[mp_adj])
@@ -91,8 +92,8 @@ def test_snap_polygon_internal():
 
     ext_snapped = [(0, 0), (0, 2.5), (2, 2.5), (2, 0), (0, 0)]
 
-    polygon = shapely.Polygon(ext, [hole])
-    polygon_snapped = shapely.Polygon(ext_snapped, [hole])
+    polygon = shapely.geometry.Polygon(ext, [hole])
+    polygon_snapped = shapely.geometry.Polygon(ext_snapped, [hole])
 
     df = gpd.GeoDataFrame(geometry=[polygon])
     expected = gpd.GeoDataFrame(geometry=[polygon_snapped])

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -158,7 +158,7 @@ _REGIONS_NATURAL_EARTH_v4_1_0 = [
         "natural_earth_v4_1_0.land_50", 1, bounds=bounds_lon_global, warn_bounds=True
     ),
     DefinedRegion("natural_earth_v4_1_0.land_10", 1, bounds=bounds_EW_S),
-    DefinedRegion("natural_earth_v4_1_0.ocean_basins_50", 119),
+    DefinedRegion("natural_earth_v4_1_0.ocean_basins_50", 119, warn_bounds=True),
 ]
 
 _REGIONS_NATURAL_EARTH_v5_0_0 = [
@@ -182,7 +182,7 @@ _REGIONS_NATURAL_EARTH_v5_0_0 = [
         "natural_earth_v5_0_0.land_50", 1, bounds=bounds_lon_global, warn_bounds=True
     ),
     DefinedRegion("natural_earth_v5_0_0.land_10", 1, bounds=bounds_EW_S),
-    DefinedRegion("natural_earth_v5_0_0.ocean_basins_50", 117),
+    DefinedRegion("natural_earth_v5_0_0.ocean_basins_50", 117, warn_bounds=True),
 ]
 
 _REGIONS_NATURAL_EARTH_v5_1_2 = [

--- a/regionmask/tests/utils.py
+++ b/regionmask/tests/utils.py
@@ -94,6 +94,7 @@ class DefinedRegion:
     n_regions: int
     overlap: bool = False
     skip_mask_test: bool = False
+    warn_bounds: Optional[bool] = False
     bounds: Optional[list[float]] = None
 
     def __str__(self):
@@ -101,56 +102,110 @@ class DefinedRegion:
         return self.region_name
 
 
+bounds_lon_min_180 = {"min_lon": -180}
+bounds_lat_min_90 = {"min_lat": -90}
+bounds_lon_max_180 = {"max_lon": 180}
+bounds_lat_max_90 = {"max_lat": 90}
+
+bounds_lon_global = bounds_lon_min_180 | bounds_lon_max_180
+bounds_lat_global = bounds_lat_min_90 | bounds_lat_max_90
+
+bounds_global = bounds_lon_global | bounds_lat_global
+
+
+bounds_EW_S = bounds_lon_global | bounds_lat_min_90
+bounds_EW_N = bounds_lon_global | bounds_lat_max_90
+
+
 REGIONS = [
-    DefinedRegion("ar6.all", 58),
-    DefinedRegion("ar6.land", 46),
-    DefinedRegion("ar6.ocean", 15),
-    DefinedRegion("giorgi", 21),
+    DefinedRegion("ar6.all", 58, bounds=bounds_global),
+    DefinedRegion("ar6.land", 46, bounds=bounds_EW_S),
+    DefinedRegion("ar6.ocean", 15, bounds=bounds_EW_N),
+    DefinedRegion("giorgi", 21, bounds=bounds_lon_max_180),
     DefinedRegion("prudence", 8, True),
-    DefinedRegion("srex", 26),
+    DefinedRegion("srex", 26, bounds=bounds_lon_max_180),
 ]
 
 
-states10_bounds = (
-    -179.1435033839999,
-    18.906117143000074,
-    179.78093509200005,
-    71.41250234600005,
-)
+states10_bounds = {
+    "min_lon": -179.1435033839999,
+    "min_lat": 18.906117143000074,
+    "max_lon": 179.78093509200005,
+    "max_lat": 71.41250234600005,
+}
 
-us_states_50_bounds = (
-    -178.19451843993753,
-    18.963909185849403,
-    -66.98702205598455,
-    71.40768682118639,
-)
+us_states_50_bounds = {
+    "min_lon": -178.19451843993753,
+    "min_lat": 18.963909185849403,
+    "max_lon": -66.98702205598455,
+    "max_lat": 71.40768682118639,
+}
 
 
 _REGIONS_NATURAL_EARTH_v4_1_0 = [
-    DefinedRegion("natural_earth_v4_1_0.countries_110", 177),
-    DefinedRegion("natural_earth_v4_1_0.countries_50", 241),
-    DefinedRegion("natural_earth_v4_1_0.countries_10", 258),
+    DefinedRegion("natural_earth_v4_1_0.countries_110", 177, bounds=bounds_EW_S),
+    DefinedRegion(
+        "natural_earth_v4_1_0.countries_50",
+        241,
+        bounds=bounds_lon_global,
+        warn_bounds=True,
+    ),
+    DefinedRegion("natural_earth_v4_1_0.countries_10", 258, bounds=bounds_EW_S),
     DefinedRegion("natural_earth_v4_1_0.us_states_50", 51, bounds=us_states_50_bounds),
     DefinedRegion("natural_earth_v4_1_0.us_states_10", 51, bounds=states10_bounds),
-    DefinedRegion("natural_earth_v4_1_0.land_110", 1),
-    DefinedRegion("natural_earth_v4_1_0.land_50", 1),
-    DefinedRegion("natural_earth_v4_1_0.land_10", 1),
+    DefinedRegion("natural_earth_v4_1_0.land_110", 1, bounds=bounds_EW_S),
+    DefinedRegion(
+        "natural_earth_v4_1_0.land_50", 1, bounds=bounds_lon_global, warn_bounds=True
+    ),
+    DefinedRegion("natural_earth_v4_1_0.land_10", 1, bounds=bounds_EW_S),
     DefinedRegion("natural_earth_v4_1_0.ocean_basins_50", 119),
 ]
 
 _REGIONS_NATURAL_EARTH_v5_0_0 = [
-    DefinedRegion("natural_earth_v5_0_0.countries_110", 177),
-    DefinedRegion("natural_earth_v5_0_0.countries_50", 242),
-    DefinedRegion("natural_earth_v5_0_0.countries_10", 258, skip_mask_test=True),
+    DefinedRegion("natural_earth_v5_0_0.countries_110", 177, bounds=bounds_EW_S),
+    DefinedRegion(
+        "natural_earth_v5_0_0.countries_50",
+        242,
+        bounds=bounds_lon_global,
+        warn_bounds=True,
+    ),
+    DefinedRegion(
+        "natural_earth_v5_0_0.countries_10",
+        258,
+        bounds=bounds_EW_S,
+        skip_mask_test=True,
+    ),
     DefinedRegion("natural_earth_v5_0_0.us_states_50", 51, bounds=us_states_50_bounds),
     DefinedRegion("natural_earth_v5_0_0.us_states_10", 51, bounds=states10_bounds),
-    DefinedRegion("natural_earth_v5_0_0.land_110", 1),
-    DefinedRegion("natural_earth_v5_0_0.land_50", 1),
-    DefinedRegion("natural_earth_v5_0_0.land_10", 1),
+    DefinedRegion("natural_earth_v5_0_0.land_110", 1, bounds=bounds_EW_S),
+    DefinedRegion(
+        "natural_earth_v5_0_0.land_50", 1, bounds=bounds_lon_global, warn_bounds=True
+    ),
+    DefinedRegion("natural_earth_v5_0_0.land_10", 1, bounds=bounds_EW_S),
     DefinedRegion("natural_earth_v5_0_0.ocean_basins_50", 117),
 ]
 
-REGIONS += _REGIONS_NATURAL_EARTH_v5_0_0
+_REGIONS_NATURAL_EARTH_v5_1_2 = [
+    DefinedRegion("natural_earth_v5_1_2.countries_110", 177, bounds=bounds_EW_S),
+    DefinedRegion("natural_earth_v5_1_2.countries_50", 242, bounds=bounds_EW_S),
+    DefinedRegion(
+        "natural_earth_v5_1_2.countries_10",
+        258,
+        bounds=bounds_EW_S,
+        skip_mask_test=True,
+    ),
+    DefinedRegion("natural_earth_v5_1_2.us_states_50", 51, bounds=us_states_50_bounds),
+    DefinedRegion("natural_earth_v5_1_2.us_states_10", 51, bounds=states10_bounds),
+    DefinedRegion("natural_earth_v5_1_2.land_110", 1, bounds=bounds_EW_S),
+    DefinedRegion("natural_earth_v5_1_2.land_50", 1, bounds=bounds_EW_S),
+    DefinedRegion("natural_earth_v5_1_2.land_10", 1, bounds=bounds_EW_S),
+    DefinedRegion("natural_earth_v5_1_2.ocean_basins_50", 117, bounds=bounds_EW_N),
+]
+
+
+REGIONS += _REGIONS_NATURAL_EARTH_v5_1_2
+
 
 REGIONS_ALL = REGIONS.copy()
 REGIONS_ALL += _REGIONS_NATURAL_EARTH_v4_1_0
+REGIONS_ALL += _REGIONS_NATURAL_EARTH_v5_0_0


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #487
 - [x] Closes #410
 - [x] Closes #357
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

This fixes regions not extending to 180°E or 90°S when they should. This concerns:
- ocean_basins_50
- land_50
- countries_50

For
- natural_earth_v4_1_0 (already in regionmask)
- natural_earth_v5_0_0 (already in regionmask)
- natural_earth_v5_1_2 (new)

I will certainly fix it for the new regions. But I am not sure what to do about the the ones that are already in regionmask:
- warn to to switch to the new one? (this is what I currently implemented)
- fix and warn?
- silently fix?

cc @senclimate @pochedls - do you have an option?

