### PR TITLE
rtd: test don't use `%matplotlib inline`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,6 +239,8 @@ man_pages = [("index", "regionmask", "regionmask Documentation", ["Mathias Hause
 # disable warnings
 warnings.filterwarnings("ignore")
 
+# don't check for frozen modules (which cannot be debuged)
+os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
 
 notebooks = (
     "notebooks/method",

--- a/docs/notebooks/method.ipynb
+++ b/docs/notebooks/method.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
+    "# :suppress:\n",
     "\n",
     "from matplotlib import rcParams\n",
     "\n",

--- a/docs/notebooks/tutorial_rst.tpl
+++ b/docs/notebooks/tutorial_rst.tpl
@@ -15,7 +15,7 @@
 {% endblock output_prompt %}
 
 {% block input %}
-{%- if cell.source.strip() and not cell.source.startswith("%") -%}
+{%- if cell.source.strip() and not (cell.source.startswith("%") or cell.source.startswith("# :suppress:")) -%}
 .. code:: python
 
 {{ cell.source | indent}}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Sometimes rtd times out in the first cell of the method.ipynb notebook, which does:

```python
%matplotlib inline

from matplotlib import rcParams

rcParams["figure.dpi"] = 300
rcParams["font.size"] = 8

import warnings

warnings.filterwarnings("ignore")
```

I'll to see if not having `%matplotlib inline` is faster. But as this is flaky behavior, we will probably not find out right now...