### PR TITLE
upsream CI: install shapely

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -20,7 +20,8 @@ python -m pip install --no-deps --upgrade --pre -i https://pypi.anaconda.org/sci
     numpy \
     pandas \
     xarray
-python -m pip install cython # for shapely
+# install build dependencies (required due to `--no-build-isolation`)
+python -m pip install cython packaging
 # may be able to remove --no-build-isolation once numpy 2 is out
 python -m pip install --no-deps --upgrade --no-build-isolation \
     --no-binary shapely rasterio \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -7,25 +7,22 @@ conda uninstall -y --force \
   geopandas \
   matplotlib-base \
   numpy \
-  pandas \
   packaging \
+  pandas \
   pooch \
   pyogrio \
   rasterio \
+  shapely \
   xarray
 # to limit the runtime of Upstream CI
-python -m pip install \
-    -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-    --no-deps \
-    --pre \
-    --upgrade \
+python -m pip install --no-deps --upgrade --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
     matplotlib \
     numpy \
     pandas \
     xarray
-python -m pip install \
-    --no-deps \
-    --upgrade \
+python -m pip install cython # for shapely
+python -m pip install --no-deps --upgrade --no-build-isolation --no-binary shapely git+https://github.com/shapely/shapely
+python -m pip install --no-deps --upgrade \
     git+https://github.com/SciTools/cartopy \
     git+https://github.com/xarray-contrib/cf-xarray \
     git+https://github.com/geopandas/geopandas \

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -21,15 +21,16 @@ python -m pip install --no-deps --upgrade --pre -i https://pypi.anaconda.org/sci
     pandas \
     xarray
 # install build dependencies (required due to `--no-build-isolation`)
-python -m pip install cython packaging
+python -m pip install cython
 # may be able to remove --no-build-isolation once numpy 2 is out
 python -m pip install --no-deps --upgrade --no-build-isolation \
-    --no-binary shapely rasterio \
-    git+https://github.com/shapely/shapely \
+    --no-binary shapely rasterio cartopy \
     git+https://github.com/SciTools/cartopy \
+    git+https://github.com/rasterio/rasterio \
+    git+https://github.com/shapely/shapely
+python -m pip install --no-deps --upgrade \
+    git+https://github.com/pypa/packaging \
     git+https://github.com/xarray-contrib/cf-xarray \
     git+https://github.com/geopandas/geopandas \
-    git+https://github.com/pypa/packaging \
     git+https://github.com/fatiando/pooch \
-    git+https://github.com/geopandas/pyogrio \
-    git+https://github.com/rasterio/rasterio
+    git+https://github.com/geopandas/pyogrio

--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -21,8 +21,10 @@ python -m pip install --no-deps --upgrade --pre -i https://pypi.anaconda.org/sci
     pandas \
     xarray
 python -m pip install cython # for shapely
-python -m pip install --no-deps --upgrade --no-build-isolation --no-binary shapely git+https://github.com/shapely/shapely
-python -m pip install --no-deps --upgrade \
+# may be able to remove --no-build-isolation once numpy 2 is out
+python -m pip install --no-deps --upgrade --no-build-isolation \
+    --no-binary shapely rasterio \
+    git+https://github.com/shapely/shapely \
     git+https://github.com/SciTools/cartopy \
     git+https://github.com/xarray-contrib/cf-xarray \
     git+https://github.com/geopandas/geopandas \


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Installs shapely in upstream dev, and fixes the numpy 2dev compatibility.
