### PR TITLE
fix typos (using codespell)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -113,7 +113,7 @@ Bug Fixes
 - Fix the detection of edge points at -180°E or 0°E if longitude values contain ``NA``
   values (:issue:`426`).
 - Fix the wrapping of longitudes that contain ``NA`` values and simplify the ``_wrapAngle``
-  function. Note the wrapping does not dependend on the longitude coordinates since
+  function. Note the wrapping does not depend on the longitude coordinates since
   :pull:`271` and thus this bug did not affect users since v0.8.0 (:pull:`425`).
 
 Docs
@@ -144,7 +144,7 @@ Breaking Changes
 - Made more arguments keyword-only for several functions and methods, e.g., for
   :py:meth:`Regions.mask` (:pull:`368`).
 - Passing ``lon_name`` and ``lat_name`` to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
-  is deprecated. Please pass the lon and lat coordinates direcly, e.g., ``mask*(ds[lon_name], ds[lat_name])``
+  is deprecated. Please pass the lon and lat coordinates directly, e.g., ``mask*(ds[lon_name], ds[lat_name])``
   (:issue:`293` and :pull:`371`).
 - Marked the ``method`` keyword to the masking methods and functions (e.g. :py:meth:`Regions.mask`)
   as internal and flagged it for removal in a future version. Passing this argument should only

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,7 +239,7 @@ man_pages = [("index", "regionmask", "regionmask Documentation", ["Mathias Hause
 # disable warnings
 warnings.filterwarnings("ignore")
 
-# don't check for frozen modules (which cannot be debuged)
+# don't check for frozen modules (which cannot be debugged)
 os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
 
 notebooks = (

--- a/docs/notebooks/detect_coords.ipynb
+++ b/docs/notebooks/detect_coords.ipynb
@@ -173,7 +173,7 @@
     "1. Passing the coordinates directly (`region.mask(lon, lat)`) takes precedence.\n",
     "1. If cf_xarray is _not_ installed regionmask will use `ds[\"lon\"]` and `ds[\"lat\"]` or raise a `KeyError`.\n",
     "1. If cf_xarray is installed the behavior is determined via the `use_cf` keyword of the `mask` and `mask_3D` methods:\n",
-    "   * `use_cf=None` (default): use the cf metadata to determine the coordinates _or_ use `ds[\"lon\"]` and `ds[\"lat\"]` (raises a `ValueError` if ambigous).\n",
+    "   * `use_cf=None` (default): use the cf metadata to determine the coordinates _or_ use `ds[\"lon\"]` and `ds[\"lat\"]` (raises a `ValueError` if ambiguous).\n",
     "   * `use_cf=True` : use the cf metadata to determine the coordinates\n",
     "   * `use_cf=False`:  use `ds[\"lon\"]` and `ds[\"lat\"]` as coordinates"
    ]

--- a/docs/notebooks/mask_2D.ipynb
+++ b/docs/notebooks/mask_2D.ipynb
@@ -584,7 +584,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again we pass the xarray object to regionmask. Here, cf_xarray is used to detect `rasm.xc` and `rasm.yc` as longitude and latitude coordinates (new in regionmask 0.10.0). Without cf_xarray we would need to pass the coordinates explicitely (i.e. `srex.mask(rasm.xc, rasm.yc`):"
+    "Again we pass the xarray object to regionmask. Here, cf_xarray is used to detect `rasm.xc` and `rasm.yc` as longitude and latitude coordinates (new in regionmask 0.10.0). Without cf_xarray we would need to pass the coordinates explicitly (i.e. `srex.mask(rasm.xc, rasm.yc`):"
    ]
   },
   {

--- a/docs/notebooks/overlap.ipynb
+++ b/docs/notebooks/overlap.ipynb
@@ -259,7 +259,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The small gray points show the gridpoint center and the vertical and horizontal lines are the gridpoint boundaries. The colored rectangles are the two regions. Here regionmask detects that certain gridpoints belong to two regions and corretly assigns them."
+    "The small gray points show the gridpoint center and the vertical and horizontal lines are the gridpoint boundaries. The colored rectangles are the two regions. Here regionmask detects that certain gridpoints belong to two regions and correctly assigns them."
    ]
   },
   {

--- a/docs/notebooks/plotting.ipynb
+++ b/docs/notebooks/plotting.ipynb
@@ -89,7 +89,7 @@
    "source": [
     "## Plot options\n",
     "\n",
-    "The `plot` method has a large number of arguments to adjust the layout of the axes. For example, you can pass a custom projection, the labels can display the abbreviation insead of the region number, the ocean can be colored, etc.. This example also shows how to use `matplotlib.patheffects` to ensure the labels are easily readable without covering too much of the map (compare to the map above):"
+    "The `plot` method has a large number of arguments to adjust the layout of the axes. For example, you can pass a custom projection, the labels can display the abbreviation instead of the region number, the ocean can be colored, etc.. This example also shows how to use `matplotlib.patheffects` to ensure the labels are easily readable without covering too much of the map (compare to the map above):"
    ]
   },
   {

--- a/regionmask/core/coords.py
+++ b/regionmask/core/coords.py
@@ -74,7 +74,7 @@ def _assert_unambigous_coord_names(obj, cf_name, name):
 
     if cf_name != name and name in obj.coords:
         raise ValueError(
-            f"Ambigous name for coordinates: cf_xarray determined '{cf_name}' but "
+            f"Ambiguous name for coordinates: cf_xarray determined '{cf_name}' but "
             f"'{name}' is also on the {type(obj).__name__}. Please set ``use_cf`` to "
             "True or False to resolve this conflict."
         )

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -68,7 +68,7 @@ wrap_lon : None | bool | 180 | 360, default: None
 
 {overlap}{flags}use_cf : bool, default: None
     Whether to use ``cf_xarray`` to infer the names of the x and y coordinates. If None
-    uses cf_xarray if the coord names are unambigous. If True requires cf_xarray if
+    uses cf_xarray if the coord names are unambiguous. If True requires cf_xarray if
     False does not use cf_xarray.
 
 Returns
@@ -311,7 +311,7 @@ def _mask_2D(
     #         "To create a 2D mask anyway, set ``overlap=False``."
     #     )
 
-    # if as_3D is not explicitely given - set it to True
+    # if as_3D is not explicitly given - set it to True
     as_3D = overlap is None
 
     mask = _mask(
@@ -467,13 +467,13 @@ def _3D_to_2D_mask(mask_3D, numbers):
     if (is_masked > 1).any():
         raise ValueError(
             "Found overlapping regions for ``overlap=None``. Please create a 3D mask. "
-            "You may want to explicitely set ``overlap`` to ``True`` or ``False``."
+            "You may want to explicitly set ``overlap`` to ``True`` or ``False``."
         )
 
     # reshape because region is the first dim
     numbers = np.asarray(numbers)
 
-    # I transform so it broadcasts (mask_3D can acually be 2D for unstructured grids,
+    # I transform so it broadcasts (mask_3D can actually be 2D for unstructured grids,
     # so reshape would need some logic)
     mask_2D = (mask_3D.T * numbers).T.sum("region")
 

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -85,7 +85,7 @@ def _obtain_ne(
         If provided, call this function on the geodataframe.
     bbox : tuple | GeoDataFrame or GeoSeries | shapely Geometry, default None
         Filter features by given bounding box, GeoSeries, GeoDataFrame or a shapely
-        geometry. See ``geopandas.read_file`` for defails.
+        geometry. See ``geopandas.read_file`` for details.
     """
 
     if query is not None:

--- a/regionmask/tests/test_mask_cf_xarray.py
+++ b/regionmask/tests/test_mask_cf_xarray.py
@@ -83,7 +83,7 @@ def test_mask_use_cf_ambigous_name(method, drop):
 
     mask = getattr(dummy_region, method)
 
-    with pytest.raises(ValueError, match="Ambigous name for coordinates"):
+    with pytest.raises(ValueError, match="Ambiguous name for coordinates"):
         mask(ds, use_cf=None)
 
 

--- a/regionmask/tests/test_mask_defined_regions.py
+++ b/regionmask/tests/test_mask_defined_regions.py
@@ -43,7 +43,7 @@ def _test_mask_equal_defined_regions(region, ds, mask_method):
 def test_mask_equal_defined_regions(defined_region, ds):
 
     if defined_region.skip_mask_test:
-        pytest.skip(reason=f"Manally skipping {defined_region.region_name}")
+        pytest.skip(reason=f"Manually skipping {defined_region.region_name}")
 
     # a loop over DATASETS is not faster - due to caching of the regions
     region = attrgetter(defined_region.region_name)(defined_regions)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

```bash
codespell --skip=".git,devel,_build" --ignore-words-list "cna,wan,nd" . --write-changes -i 3
```