### PR TITLE
mask_to_dataarray: avoid internal xarray method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,7 @@ Docs
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Restore compatibility with upcoming xarray release (probably v2023.04 or v2024.04, :pull:`#512`).
 - Small optimizations for :py:class:`Regions` (:pull:`#478`).
 
 

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -588,7 +588,7 @@ def mask_to_dataarray(mask, lon, lat, lon_name="lon", lat_name="lat"):
 
     ds = lat.coords.merge(lon.coords)
 
-    dims = xr.core.variable.broadcast_variables(lat.variable, lon.variable)[0].dims
+    dims = xr.broadcast(lat, lon)[0].dims
 
     # unstructured grids are 1D
     if mask.ndim - 1 == len(dims):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #463
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
