### PR TITLE
rtd: use pip via conda

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -6,35 +6,37 @@ channels:
 
 dependencies:
   - python=3.12
-# regionmask dependencies
-  - cartopy
-  - geopandas
-  - matplotlib-base
-  - numpy
-  - packaging
-  - pooch
-  - pyogrio
-  - rasterio
-  - xarray
-# dependencies for the examples
-  - cf_xarray
-  - cftime
-  - netcdf4
-# for regionmask intake example
-  - aiohttp
-  - fsspec==0.8.7
-  - intake
-  - requests
-# dependencies to build the docu
-  - ipykernel
-  - nbconvert
-  - numpydoc
-  - pillow
+  - pandoc
   - pip
-  - sphinx
-  - sphinx_rtd_theme
-# for regionmask intake example
   - pip:
+    # regionmask dependencies
+    - cartopy
+    - geopandas
+    - matplotlib-base
+    - numpy
+    - packaging
+    - pooch
+    - pyogrio
+    - rasterio
+    - xarray
+    # dependencies for the examples
+    - cf_xarray
+    - cftime
+    - netcdf4
+    # for regionmask intake example
+    - aiohttp
+    - fsspec==0.8.7
+    - intake
+    - requests
+    # dependencies to build the docu
+    - ipykernel
+    - nbconvert
+    - numpydoc
+    - pillow
+    - pip
+    - sphinx
+    - sphinx_rtd_theme
+    # for regionmask intake example
     - intake_geopandas>=0.2.4
     - msgpack
     - sphinxext-rediraffe

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -12,7 +12,7 @@ dependencies:
     # regionmask dependencies
     - cartopy
     - geopandas
-    - matplotlib-base
+    - matplotlib
     - numpy
     - packaging
     - pooch


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #447
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`


Another stab at #447 (after #450) - uses conda for pandoc, which would avoid the old version provided by ubuntu-22.04.