### PR TITLE
fix rasterio dev dtype

### DIFF
--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -918,6 +918,9 @@ def _mask_rasterize_no_offset(
     transform = _transform_from_latlon(lon, lat)
     out_shape = (len(lat), len(lon))
 
+    # can remove once https://github.com/rasterio/rasterio/issues/3043 is fixed
+    dtype = dtype if dtype is None else np.dtype(dtype).name
+
     raster = features.rasterize(
         shapes,
         out_shape=out_shape,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Fix for https://github.com/rasterio/rasterio/issues/3043. Not really necessary, but I want to get upsream-dev running.