### PR TITLE
workaround for matplotlib-numpy v2 failures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ Internal Changes
 ~~~~~~~~~~~~~~~~
 
 - Get upstream-dev CI to run with numpy 2.0 (:pull:`522`) and fix accrued upstream failures
-  for rasterio (:pull:`524`) and cartopy (:pull:`525`).
+  for rasterio (:pull:`524`), cartopy (:pull:`525`), and matplotlib (:pull:`527`).
 
 
 .. _changelog.0.12.1:

--- a/regionmask/tests/test_plot.py
+++ b/regionmask/tests/test_plot.py
@@ -285,11 +285,11 @@ def test_plot_lines(plotfunc):
     with figure_context():
         ax = func(tolerance=None, **maybe_no_coastlines(plotfunc))
 
-        lines = ax.collections[0].get_segments()
+        lines = ax.collections[0].get_paths()
 
         assert len(lines) == 2
-        assert np.allclose(lines[0], outl1_closed)
-        assert np.allclose(lines[1], outl2_closed)
+        assert np.allclose(lines[0].vertices, outl1_closed)
+        assert np.allclose(lines[1].vertices, outl2_closed)
 
 
 @requires_matplotlib
@@ -301,11 +301,11 @@ def test_plot_lines_float_numbers(plotfunc):
     with figure_context():
         ax = func(tolerance=None, **maybe_no_coastlines(plotfunc))
 
-        lines = ax.collections[0].get_segments()
+        lines = ax.collections[0].get_paths()
 
         assert len(lines) == 2
-        assert np.allclose(lines[0], outl1_closed)
-        assert np.allclose(lines[1], outl2_closed)
+        assert np.allclose(lines[0].vertices, outl1_closed)
+        assert np.allclose(lines[1].vertices, outl2_closed)
 
 
 @requires_matplotlib
@@ -319,10 +319,10 @@ def test_plot_lines_multipoly(plotfunc):
     with figure_context():
         ax = func(tolerance=None, **maybe_no_coastlines(plotfunc))
 
-        lines = ax.collections[0].get_segments()
+        lines = ax.collections[0].get_paths()
         assert len(lines) == 2
-        assert np.allclose(lines[0], outl1_closed)
-        assert np.allclose(lines[1], outl2_closed)
+        assert np.allclose(lines[0].vertices, outl1_closed)
+        assert np.allclose(lines[1].vertices, outl2_closed)
 
 
 # -----------------------------------------------------------------------------
@@ -336,10 +336,10 @@ def test_plot_lines_selection(plotfunc):
         func = getattr(r1[0, 1], plotfunc)
 
         ax = func(tolerance=None, **maybe_no_coastlines(plotfunc))
-        lines = ax.collections[0].get_segments()
+        lines = ax.collections[0].get_paths()
         assert len(lines) == 2
-        assert np.allclose(lines[0], outl1_closed)
-        assert np.allclose(lines[1], outl2_closed)
+        assert np.allclose(lines[0].vertices, outl1_closed)
+        assert np.allclose(lines[1].vertices, outl2_closed)
 
 
 @requires_matplotlib
@@ -430,10 +430,10 @@ def test_plot_lines_from_poly(plotfunc):
 
     with figure_context():
         ax = func(**maybe_no_coastlines(plotfunc))
-        lines = ax.collections[0].get_segments()
+        lines = ax.collections[0].get_paths()
 
         assert len(lines) == 2
-        assert np.allclose(lines[0], r2.polygons[0].exterior.coords)
+        assert np.allclose(lines[0].vertices, r2.polygons[0].exterior.coords)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #526
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

It's a workaround, but should not matter here (not clear if one or the other approach is in any way better).
