### PR TITLE
min_deps_check: show age of required pkg on error

### DIFF
--- a/ci/min_deps_check.py
+++ b/ci/min_deps_check.py
@@ -134,7 +134,7 @@ def process_pkg(
     - publication date of version suggested by policy (YYYY-MM-DD)
     - status ("<", "=", "> (!)")
     """
-    print("Analyzing %s..." % pkg)
+    print(f"Analyzing {pkg}...")
     versions = query_conda(pkg)
 
     try:
@@ -163,11 +163,11 @@ def process_pkg(
         status = "<"
     elif (req_major, req_minor) > (policy_major, policy_minor):
         status = "> (!)"
-        delta = relativedelta(datetime.now(), policy_published_actual).normalized()
+        delta = relativedelta(datetime.now(), req_published).normalized()
         n_months = delta.years * 12 + delta.months
         warning(
-            f"Package is too new: {pkg}={policy_major}.{policy_minor} was "
-            f"published on {versions[policy_major, policy_minor]:%Y-%m-%d} "
+            f"Package is too new: {pkg}={req_major}.{req_minor} was "
+            f"published on {req_published:%Y-%m-%d} "
             f"which was {n_months} months ago (policy is {policy_months} months)"
         )
     else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Show the age of the 'user-requested' package (i.e. the one in min-all-deps.yml) and not of the 'policy-required' when running min_deps_check.py.