### PR TITLE
upstream CI: install pyogrio

### DIFF
--- a/ci/install-upstream-wheels.sh
+++ b/ci/install-upstream-wheels.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# NOTE: pyogrio is not tested as it is a optional dependency
-
 # forcibly remove packages to avoid artifacts
 conda uninstall -y --force \
   cartopy \
@@ -36,8 +34,10 @@ python -m pip install \
     git+https://github.com/geopandas/geopandas \
     git+https://github.com/pypa/packaging \
     git+https://github.com/fatiando/pooch
-python -m pip install cython # to build rasterio
+python -m pip install cython # to build rasterio & pyogrio
+python -m pip install versioneer # to build pyogrio
 python -m pip install \
     --no-deps \
     --no-build-isolation \
-    git+https://github.com/rasterio/rasterio
+    git+https://github.com/rasterio/rasterio \
+    git+https://github.com/geopandas/pyogrio


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #537

Install pygrio in upstream-dev CI as fiona is no longer present (and pygrio is now the default)