### PR TITLE
bump rasterio to v1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 
 - Drop support for pygeos, which was replaced by shapely v2.0 (:pull:`519`).
+- Bumped minimum rasterio version to v1.3 (:issue:`347`).
 
 Enhancements
 ~~~~~~~~~~~~

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -14,7 +14,7 @@ dependencies:
   - pooch=1.4
   # pyogrio makes environment solving difficult
   - pyogrio=0.3
-  - rasterio=1.2
+  - rasterio=1.3
   - shapely=1.8
   - xarray=0.20
 # for testing

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ Required dependencies
 - `numpy <http://www.numpy.org/>`__ (1.21 or later)
 - `packaging <https://packaging.pypa.io/en/latest/>`__ (21.3 or later)
 - `pooch <https://www.fatiando.org/pooch/latest/>`__ (1.4 or later)
-- `rasterio <https://rasterio.readthedocs.io/>`__ (1.2 or later)
+- `rasterio <https://rasterio.readthedocs.io/>`__ (1.3 or later)
 - `shapely <http://toblerity.org/shapely/>`__ (1.8 or later)
 - `xarray <http://xarray.pydata.org/>`__ (0.20 or later)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ geopandas >= 0.10
 numpy >= 1.21
 packaging >= 21.3
 pooch >= 1.4
-rasterio >= 1.2
+rasterio >= 1.3
 shapely >= 1.8
 xarray >= 0.20

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     numpy >= 1.21
     packaging >= 21.3
     pooch >= 1.4
-    rasterio >= 1.2
+    rasterio >= 1.3
     shapely >= 1.8
     xarray >= 0.20
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #347
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
