### PR TITLE
bump versions of dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,23 @@ Breaking Changes
 - Drop support for pygeos, which was replaced by shapely v2.0 (:pull:`519`).
 - Bumped minimum rasterio version to v1.3 (:issue:`347`).
 
+- The minimum versions of some dependencies were changed (:pull:`541`):
+
+  ============ ===== =====
+  Package      Old   New
+  ============ ===== =====
+  cartopy*     0.20  0.22
+  cf_xarray*   0.7   0.8
+  geopandas    0.10   0.13
+  matplotlib*  3.5   3.7
+  numpy        1.21  1.24
+  pandas       1.3   2.0
+  pooch        1.4   1.7
+  rasterio     1.2   1.3
+  shapely      1.8   1.8
+  xarray       0.20  2023.07
+  ============ ===== =====
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -4,19 +4,19 @@ channels:
   - nodefaults
 dependencies:
   - python=3.9
-  - cartopy=0.20
-  - cf_xarray=0.7
-  - geopandas=0.10
-  - matplotlib-base=3.5
-  - numpy=1.21
-  - packaging=21.3
-  - pandas=1.3
-  - pooch=1.4
+  - cartopy=0.22
+  - cf_xarray=0.8
+  - geopandas=0.13
+  - matplotlib-base=3.7
+  - numpy=1.24
+  - packaging=23.1
+  - pandas=2.0
+  - pooch=1.7
   # pyogrio makes environment solving difficult
-  - pyogrio=0.3
+  - pyogrio=0.5
   - rasterio=1.3
   - shapely=1.8
-  - xarray=0.20
+  - xarray=2023.7
 # for testing
   - pytest
   - pytest-cov

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,13 +5,13 @@ Required dependencies
 ---------------------
 
 - Python (3.9 or later)
-- `geopandas <http://geopandas.org/>`__ (0.10 or later)
-- `numpy <http://www.numpy.org/>`__ (1.21 or later)
-- `packaging <https://packaging.pypa.io/en/latest/>`__ (21.3 or later)
-- `pooch <https://www.fatiando.org/pooch/latest/>`__ (1.4 or later)
+- `geopandas <http://geopandas.org/>`__ (0.13 or later)
+- `numpy <http://www.numpy.org/>`__ (1.24 or later)
+- `packaging <https://packaging.pypa.io/en/latest/>`__ (23.1 or later)
+- `pooch <https://www.fatiando.org/pooch/latest/>`__ (1.7 or later)
 - `rasterio <https://rasterio.readthedocs.io/>`__ (1.3 or later)
 - `shapely <http://toblerity.org/shapely/>`__ (1.8 or later)
-- `xarray <http://xarray.pydata.org/>`__ (0.20 or later)
+- `xarray <http://xarray.pydata.org/>`__ (2023.07 or later)
 
 Optional dependencies
 ---------------------
@@ -19,21 +19,21 @@ Optional dependencies
 For plotting
 ~~~~~~~~~~~~
 
-- `matplotlib <http://matplotlib.org>`__ (3.5 or later) is required to create any plots.
-- `cartopy <https://scitools.org.uk/cartopy/docs/latest>`__ (0.20 or later) for plotting on
+- `matplotlib <http://matplotlib.org>`__ (3.7 or later) is required to create any plots.
+- `cartopy <https://scitools.org.uk/cartopy/docs/latest>`__ (0.22 or later) for plotting on
   maps.
 
 For detecting coords and parsing flag values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `cf_xarray <https://cf-xarray.readthedocs.io/en/latest/>`__ (0.7 or later) allows
+- `cf_xarray <https://cf-xarray.readthedocs.io/en/latest/>`__ (0.8 or later) allows
   to autodetect coordidate names and rich comparison of abbreviations or names of regions
   for 2D masks via ``mask.cf``.
 
 For faster loading of shapefiles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `pyogrio <https://pyogrio.readthedocs.io>`__ (0.3 or later) allows faster reading of
+- `pyogrio <https://pyogrio.readthedocs.io>`__ (0.5 or later) allows faster reading of
   shapefiles. Currently only used for natural earth data (as the other data is loaded
   reasonanbly fast with fiona).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 # it exists to let GitHub build the repository dependency graph
 # https://help.github.com/en/github/visualizing-repository-data-with-graphs/listing-the-packages-that-a-repository-depends-on
 
-geopandas >= 0.10
-numpy >= 1.21
-packaging >= 21.3
-pooch >= 1.4
+geopandas >= 0.13
+numpy >= 1.24
+packaging >= 23.1
+pooch >= 1.7
 rasterio >= 1.3
 shapely >= 1.8
-xarray >= 0.20
+xarray >= 2023.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,23 +28,23 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.9
 install_requires =
-    geopandas >= 0.10
-    numpy >= 1.21
-    packaging >= 21.3
-    pooch >= 1.4
+    geopandas >= 0.13
+    numpy >= 1.24
+    packaging >= 23.1
+    pooch >= 1.7
     rasterio >= 1.3
     shapely >= 1.8
-    xarray >= 0.20
+    xarray >= 2023.07
 
 
 [options.extras_require]
 plot =
-    cartopy >= 0.20
-    matplotlib >= 3.5
+    cartopy >= 0.22
+    matplotlib >= 3.7
 
 full =
     %(plot)s
-    cf_xarray >= 0.7
+    cf_xarray >= 0.8
 
 
 [tool:pytest]


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Part of #542, addresses the road block https://github.com/regionmask/regionmask/pull/521#issuecomment-2107090364
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [x] Fully documented, including `whats-new.rst`

Relatively aggressive bump of versions (for my standards) but might still be a moment before a new version comes out. Necessary preparation for #521
