### PR TITLE
bump pyogrio

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Breaking Changes
 - Require shapely v2.0+ (:pull:`521`).
 - Bumped minimum rasterio version to v1.3 (:issue:`347`).
 
-- The minimum versions of some dependencies were changed (:pull:`541`, :pull:`546`, and :pull:`521`):
+- The minimum versions of some dependencies were changed (:pull:`541`, :pull:`546`, :pull:`521`, and :pull:`547`):
 
   ============ ===== =====
   Package      Old   New
@@ -32,6 +32,7 @@ Breaking Changes
   matplotlib*  3.5   3.7
   numpy        1.21  1.24
   pandas       1.3   2.0
+  pygrio*      0.3   0.6
   pooch        1.4   1.7
   rasterio     1.2   1.3
   shapely      1.8   2.0

--- a/ci/requirements/min-all-deps.yml
+++ b/ci/requirements/min-all-deps.yml
@@ -12,8 +12,7 @@ dependencies:
   - packaging=23.1
   - pandas=2.0
   - pooch=1.7
-  # pyogrio makes environment solving difficult
-  - pyogrio=0.5
+  - pyogrio=0.6
   - rasterio=1.3
   - shapely=2.0
   - xarray=2023.7

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -33,7 +33,7 @@ For detecting coords and parsing flag values
 For faster loading of shapefiles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- `pyogrio <https://pyogrio.readthedocs.io>`__ (0.5 or later) allows faster reading of
+- `pyogrio <https://pyogrio.readthedocs.io>`__ (0.6 or later) allows faster reading of
   shapefiles. Currently only used for natural earth data (as the other data is loaded
   reasonanbly fast with fiona).
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

We can bump pygrio again after requiring shapely v2.0+
