### PR TITLE
finalize deprecate positional args

### DIFF
--- a/regionmask/core/_geopandas.py
+++ b/regionmask/core/_geopandas.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 
-from regionmask.core._deprecate import _deprecate_positional_args
 from regionmask.core.mask import _inject_mask_docstring, _mask_2D, _mask_3D
 from regionmask.core.regions import Regions
 from regionmask.defined_regions._natural_earth import _maybe_get_column
@@ -59,7 +58,6 @@ def _construct_abbrevs(geodataframe, names):
     return abbrevs
 
 
-@_deprecate_positional_args("0.10.0")
 def from_geopandas(
     geodataframe,
     *,
@@ -213,7 +211,6 @@ def _prepare_gdf_for_mask(geodataframe, numbers):
 # TODO: switch order of use_cf and overlap once the deprecation is finished
 
 
-@_deprecate_positional_args("0.10.0")
 def mask_geopandas(
     geodataframe,
     lon_or_obj,
@@ -254,7 +251,6 @@ def mask_geopandas(
 mask_geopandas.__doc__ = _inject_mask_docstring(which="2D", is_gpd=True)
 
 
-@_deprecate_positional_args("0.10.0")
 def mask_3D_geopandas(
     geodataframe,
     lon_or_obj,

--- a/regionmask/core/regions.py
+++ b/regionmask/core/regions.py
@@ -11,7 +11,6 @@ import numpy as np
 import pandas as pd
 from shapely.geometry import MultiPolygon, Polygon
 
-from regionmask.core._deprecate import _deprecate_positional_args
 from regionmask.core.formatting import _display
 from regionmask.core.mask import (
     _inject_mask_docstring,
@@ -321,7 +320,6 @@ class Regions:
 
         return self._display(max_rows=max_rows)
 
-    @_deprecate_positional_args("0.10.0")
     def mask(
         self,
         lon_or_obj,
@@ -379,7 +377,6 @@ class Regions:
 
     mask.__doc__ = _inject_mask_docstring(which="2D", is_gpd=False)
 
-    @_deprecate_positional_args("0.10.0")
     def mask_3D(
         self,
         lon_or_obj,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

I will remove the function `_deprecate_positional_args` in a separate PR