### PR TITLE
avoid shapely.vectorized

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,8 @@ Internal Changes
 
 - Get upstream-dev CI to run with numpy 2.0 (:pull:`522`) and fix accrued upstream failures
   for rasterio (:pull:`524`), cartopy (:pull:`525`), and matplotlib (:pull:`527`).
+- Avoid usage of `shapely.vectorized` which might be removed in a future version of
+  shapely (:pull:`554`).
 
 
 .. _changelog.0.12.1:

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -595,7 +595,6 @@ def _mask_edgepoints_shapely(
     as_3D=False,
 ):
 
-    import shapely.vectorized
 
     LON, LAT, shape = _get_LON_LAT_shape(
         lon, lat, numbers, is_unstructured=is_unstructured, as_3D=as_3D
@@ -636,14 +635,16 @@ def _mask_edgepoints_shapely(
     # "mask[borderpoints][sel] = number" does not work, need to use np.where
     idx = np.where(borderpoints)[0]
 
+    polys = np.array(polygons).reshape(-1, 1)
+    arr = shapely.contains_xy(polys, LON, LAT)
+
     if as_3D:
-        for i, polygon in enumerate(polygons):
-            sel = shapely.vectorized.contains(polygon, LON, LAT)
-            mask[i, idx[sel]] = True
+        for i in range(len(polygons)):
+            mask[i, idx[arr[i, :]]] = True
+
     else:
-        for i, polygon in enumerate(polygons):
-            sel = shapely.vectorized.contains(polygon, LON, LAT)
-            mask[idx[sel]] = numbers[i]
+        for i in range(len(polygons)):
+            mask[idx[arr[i, :]]] = numbers[i]
 
     return mask.reshape(shape)
 

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -595,7 +595,6 @@ def _mask_edgepoints_shapely(
     as_3D=False,
 ):
 
-
     LON, LAT, shape = _get_LON_LAT_shape(
         lon, lat, numbers, is_unstructured=is_unstructured, as_3D=as_3D
     )


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Avoids `shapely.verctorized` which may be removed in the future shapely/shapely/issues/1630. In shapely v2 this is no longer faster/ optimized.