### PR TITLE
add python 3.13 to supported versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.13"]
         env: [""]
         include:
           - env: "bare-minimum"

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -46,17 +46,12 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
             pytest-reportlog
-            conda
       - name: Install upstream versions
         run: |
           bash ci/install-upstream-wheels.sh
       - name: Install regionmask
         run: |
           python -m pip install --no-deps -e .
-      - name: Version info
-        run: |
-          conda info -a
-          conda list
 
       - name: Import regionmask
         run: |

--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Breaking Changes
 Enhancements
 ~~~~~~~~~~~~
 
+- Add python 3.12 to list of supported versions (:pull:`565`).
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Atmospheric Science
     Topic :: Scientific/Engineering :: GIS


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Interested to see if the dependencies are ready...