### PR TITLE
fix coverage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
           flags: unittests
           env_vars: RUNNER_OS,PYTHON_VERSION
           name: codecov-umbrella

--- a/regionmask/core/formatting.py
+++ b/regionmask/core/formatting.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from pandas.io.formats import console  # type:ignore[attr-defined]
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from regionmask.core.regions import Regions
 
 

--- a/regionmask/core/plot.py
+++ b/regionmask/core/plot.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from regionmask.core.utils import _flatten_polygons, flatten_3D_mask
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from cartopy.mpl.geoaxes import GeoAxes
     from matplotlib.axes import Axes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,5 +91,4 @@ force_to_top = true
 omit =
     */regionmask/tests/*
 
-[coverage:report]
-exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
+


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

Maybe it was not the update of codecov but the config change?
