### PR TITLE
finalize deprecation of lat_name and lon_name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Docs
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Remove lat_name and lon_name internally (:pull:`592`).
+
 
 .. _changelog.0.13.0:
 

--- a/regionmask/core/mask.py
+++ b/regionmask/core/mask.py
@@ -316,7 +316,7 @@ def _mask_3D_frac_approx(
         mask[:, 0] = e1
         mask[:, -1] = e2
 
-    mask = _mask_to_dataarray(mask, lon_, lat_, lon_name="lon", lat_name="lat")
+    mask = _mask_to_dataarray(mask, lon_, lat_)
 
     mask_3D = _3D_to_3D_mask(mask, numbers, drop)
 
@@ -536,13 +536,13 @@ def _determine_method(
     return "shapely"
 
 
-def _mask_to_dataarray(mask, lon, lat, lon_name="lon", lat_name="lat") -> xr.DataArray:
+def _mask_to_dataarray(mask, lon, lat) -> xr.DataArray:
 
     if sum(isinstance(c, xr.DataArray) for c in (lon, lat)) == 1:
         raise ValueError("Cannot handle coordinates with mixed types!")
 
     if not isinstance(lon, xr.DataArray) or not isinstance(lat, xr.DataArray):
-        lon, lat = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
+        lon, lat = _numpy_coords_to_dataarray(lon, lat)
 
     ds = lat.coords.merge(lon.coords)
 
@@ -555,10 +555,9 @@ def _mask_to_dataarray(mask, lon, lat, lon_name="lon", lat_name="lat") -> xr.Dat
     return ds.assign(mask=(dims, mask)).mask
 
 
-def _numpy_coords_to_dataarray(
-    lon, lat, lon_name, lat_name
-) -> tuple[xr.DataArray, xr.DataArray]:
-    # TODO: simplify if passing lon_name and lat_name is no longer supported
+def _numpy_coords_to_dataarray(lon, lat) -> tuple[xr.DataArray, xr.DataArray]:
+
+    lon_name, lat_name = "lon", "lat"
 
     dims2D = (f"{lat_name}_idx", f"{lon_name}_idx")
 

--- a/regionmask/tests/test_create_dataarray.py
+++ b/regionmask/tests/test_create_dataarray.py
@@ -90,62 +90,52 @@ def test_mask_to_dataarray_3D_mask(n_regions, ds, lon_name, lat_name, mask) -> N
 
 @pytest.mark.parametrize("lon", ([0, 1], np.array([0.1, 2.3])))
 @pytest.mark.parametrize("lat", ([2, 3], np.array([-1.75, 23.85])))
-@pytest.mark.parametrize("lon_name", ("lon", "longitude"))
-@pytest.mark.parametrize("lat_name", ("lat", "latitude"))
-def test_mask_to_dataarray_numpy_1D(lon, lat, lon_name, lat_name) -> None:
+def test_mask_to_dataarray_numpy_1D(lon, lat) -> None:
 
     mask = np.arange(4).reshape(2, 2)
-    actual = _mask_to_dataarray(mask, lon, lat, lon_name, lat_name)
-    expected = xr.DataArray(
-        mask, dims=(lat_name, lon_name), coords={lat_name: lat, lon_name: lon}
-    )
+    actual = _mask_to_dataarray(mask, lon, lat)
+    expected = xr.DataArray(mask, dims=("lat", "lon"), coords={"lat": lat, "lon": lon})
     xr.testing.assert_equal(expected, actual)
 
 
-@pytest.mark.parametrize("lon_name", ("lon", "longitude", "x"))
-@pytest.mark.parametrize("lat_name", ("lat", "latitude", "y"))
-def test_mask_to_dataarray_numpy_2D(lon_name, lat_name) -> None:
+def test_mask_to_dataarray_numpy_2D() -> None:
 
     lon = [[0, 1], [0, 1]]
     lat = [[1, 1], [0, 0]]
 
     mask = np.arange(4).reshape(2, 2)
-    actual = _mask_to_dataarray(mask, lon, lat, lon_name, lat_name)
-    dims = (f"{lat_name}_idx", f"{lon_name}_idx")
+    actual = _mask_to_dataarray(mask, lon, lat)
+    dims = ("lat_idx", "lon_idx")
     expected = xr.DataArray(
-        mask, dims=dims, coords={lat_name: (dims, lat), lon_name: (dims, lon)}
+        mask, dims=dims, coords={"lat": (dims, lat), "lon": (dims, lon)}
     )
     xr.testing.assert_equal(expected, actual)
 
 
-@pytest.mark.parametrize("lon_name", ("lon", "longitude", "x"))
-@pytest.mark.parametrize("lat_name", ("lat", "latitude", "y"))
-def test_numpy_coords_to_dataarray_1D(lon_name, lat_name) -> None:
+def test_numpy_coords_to_dataarray_1D() -> None:
 
     lon = [0, 1]
     lat = [0, 1]
 
-    lon_actual, lat_actual = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
+    lon_actual, lat_actual = _numpy_coords_to_dataarray(lon, lat)
 
-    lon_expected = xr.Dataset(coords={lon_name: lon})[lon_name]
-    lat_expected = xr.Dataset(coords={lat_name: lat})[lat_name]
+    lon_expected = xr.Dataset(coords={"lon": lon})["lon"]
+    lat_expected = xr.Dataset(coords={"lat": lat})["lat"]
 
     xr.testing.assert_equal(lon_expected, lon_actual)
     xr.testing.assert_equal(lat_expected, lat_actual)
 
 
-@pytest.mark.parametrize("lon_name", ("lon", "longitude", "x"))
-@pytest.mark.parametrize("lat_name", ("lat", "latitude", "y"))
-def test_numpy_coords_to_dataarray_2D(lon_name, lat_name) -> None:
+def test_numpy_coords_to_dataarray_2D() -> None:
 
     lon = [[0, 1]]
     lat = [[0, 1]]
 
-    lon_actual, lat_actual = _numpy_coords_to_dataarray(lon, lat, lon_name, lat_name)
+    lon_actual, lat_actual = _numpy_coords_to_dataarray(lon, lat)
 
-    dims = (f"{lat_name}_idx", f"{lon_name}_idx")
-    lon_expected = xr.Dataset(coords={lon_name: (dims, lon)})[lon_name]
-    lat_expected = xr.Dataset(coords={lat_name: (dims, lat)})[lat_name]
+    dims = ("lat_idx", "lon_idx")
+    lon_expected = xr.Dataset(coords={"lon": (dims, lon)})["lon"]
+    lat_expected = xr.Dataset(coords={"lat": (dims, lat)})["lat"]
 
     xr.testing.assert_equal(lon_expected, lon_actual)
     xr.testing.assert_equal(lat_expected, lat_actual)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`

It's no longer accessible from `mask*` - so might as well.
