### PR TITLE
fix misspelled words (using typos)

### DIFF
--- a/docs/source/defined_scientific.rst
+++ b/docs/source/defined_scientific.rst
@@ -4,7 +4,7 @@ Scientific Regions
 
 The following regions, used in the scientific literature, are available in regionmask:
 
-* `Giorgi Regions`_ (from Giorgi and Franciso, 2000)
+* `Giorgi Regions`_ (from Giorgi and Francisco, 2000)
 * `SREX Regions`_ (Special Report on Managing the Risks of Extreme Events and Disasters to Advance Climate Change Adaptation (SREX) from Seneviratne et al., 2012)
 * `AR6 Regions`_ (Iturbide et al., 2020; ESSD)
 * `PRUDENCE Regions`_ (from European Regional Climate Modelling PRUDENCE Project, Christensen and Christensen, 2007)
@@ -141,6 +141,6 @@ The PRUDENCE regions were defined in the PRUDENCE project as European sub-areas 
 References
 ==========
 * Christensen and Christensen (`2007 <https://link.springer.com/article/10.1007/s10584-006-9210-7>`_)
-* Giorgi and Franciso (`2000 <http://onlinelibrary.wiley.com/doi/10.1029/1999GL011016>`_)
+* Giorgi and Francisco (`2000 <http://onlinelibrary.wiley.com/doi/10.1029/1999GL011016>`_)
 * Iturbide et al., (`2020 <https://doi.org/10.5194/essd-12-2959-2020>`_)
 * Seneviratne et al., (`2012 <https://www.ipcc.ch/pdf/special-reports/srex/SREX-Ch3-Supplement_FINAL.pdf>`_)

--- a/docs/source/notebooks/geopandas.ipynb
+++ b/docs/source/notebooks/geopandas.ipynb
@@ -81,7 +81,7 @@
    "source": [
     "## Opening an example shapefile\n",
     "\n",
-    "The U.S. Geological Survey (USGS) offers a shapefile containing the outlines of continens [1]. We use the library pooch to locally cache the file:"
+    "The U.S. Geological Survey (USGS) offers a shapefile containing the outlines of continents [1]. We use the library pooch to locally cache the file:"
    ]
   },
   {

--- a/docs/source/notebooks/mask_3D_frac_approx.ipynb
+++ b/docs/source/notebooks/mask_3D_frac_approx.ipynb
@@ -262,7 +262,7 @@
    "source": [
     "### Calculate weighted regional averages\n",
     "\n",
-    "As for the boolan 3D mask, we can calculate the regional averages using fractional mask. In this case each grid point contributes according to its overlap and area. As proxy of the grid cell area we use `cos(lat)`."
+    "As for the boolean 3D mask, we can calculate the regional averages using fractional mask. In this case each grid point contributes according to its overlap and area. As proxy of the grid cell area we use `cos(lat)`."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,35 @@ module = [
   "rasterio.*",
   "shapely.*",
 ]
+
+[tool.typos]
+
+[tool.typos.default]
+extend-ignore-identifiers-re = [
+  # Variable names
+  "nd_.*",
+  ".*_nd",
+  # Function/class names
+  "NDArray.*",
+  ".*NDArray.*",
+]
+
+[tool.typos.default.extend-words]
+
+# regions
+
+CNA = "CNA"
+
+# NumPy function names
+arange = "arange"
+
+# Names
+Francisco = "Francisco"
+
+nd = "nd"
+
+[tool.typos.type.jupyter]
+# avoid fixing the id hashes in jupyter notebooks
+extend-ignore-re = [
+    "\"id\": \".*\"",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,15 +73,10 @@ extend-ignore-identifiers-re = [
 [tool.typos.default.extend-words]
 
 # regions
-
 CNA = "CNA"
 
-# NumPy function names
+# numpy
 arange = "arange"
-
-# Names
-Francisco = "Francisco"
-
 nd = "nd"
 
 [tool.typos.type.jupyter]

--- a/regionmask/core/coords.py
+++ b/regionmask/core/coords.py
@@ -64,13 +64,13 @@ def _get_coords_cf_or_name(obj, lon_name, lat_name):
     x_name = _get_cf_coords(obj, "longitude", required=False) or lon_name
     y_name = _get_cf_coords(obj, "latitude", required=False) or lat_name
 
-    _assert_unambigous_coord_names(obj, x_name, lon_name)
-    _assert_unambigous_coord_names(obj, y_name, lat_name)
+    _assert_unambiguous_coord_names(obj, x_name, lon_name)
+    _assert_unambiguous_coord_names(obj, y_name, lat_name)
 
     return obj[x_name], obj[y_name]
 
 
-def _assert_unambigous_coord_names(obj, cf_name, name):
+def _assert_unambiguous_coord_names(obj, cf_name, name):
 
     if cf_name != name and name in obj.coords:
         raise ValueError(

--- a/regionmask/defined_regions/__init__.py
+++ b/regionmask/defined_regions/__init__.py
@@ -1,4 +1,4 @@
-from regionmask.defined_regions import _natural_earth, _ressources
+from regionmask.defined_regions import _natural_earth, _resources
 from regionmask.defined_regions._ar6 import ar6
 from regionmask.defined_regions._natural_earth import (
     natural_earth_v4_1_0,
@@ -11,7 +11,7 @@ from regionmask.defined_regions.srex import srex
 
 __all__ = [
     "_natural_earth",
-    "_ressources",
+    "_resources",
     "ar6",
     "natural_earth_v4_1_0",
     "natural_earth_v5_0_0",

--- a/regionmask/defined_regions/_ar6.py
+++ b/regionmask/defined_regions/_ar6.py
@@ -2,7 +2,7 @@ from functools import cache
 
 from regionmask.core._geopandas import from_geopandas
 from regionmask.core.regions import Regions
-from regionmask.defined_regions._ressources import read_remote_shapefile
+from regionmask.defined_regions._resources import read_remote_shapefile
 
 REPR = """
 AR6 reference regions - Iturbide et al., 2020

--- a/regionmask/defined_regions/_natural_earth.py
+++ b/regionmask/defined_regions/_natural_earth.py
@@ -11,7 +11,7 @@ from shapely.geometry import MultiPolygon
 
 from regionmask.core.regions import Regions
 from regionmask.core.utils import _flatten_polygons, _snap_to_90S, _snap_to_180E
-from regionmask.defined_regions._ressources import _get_cache_dir
+from regionmask.defined_regions._resources import _get_cache_dir
 
 try:
     import pyogrio  # noqa: F401

--- a/regionmask/defined_regions/_resources.py
+++ b/regionmask/defined_regions/_resources.py
@@ -18,7 +18,7 @@ def fetch_remote_shapefile(name):
     uses pooch to cache files
     """
 
-    REMOTE_RESSOURCE = pooch.create(
+    REMOTE_RESOURCE = pooch.create(
         # Use the default cache folder for the OS
         path=_get_cache_dir(),
         # The remote data is on Github
@@ -34,7 +34,7 @@ def fetch_remote_shapefile(name):
     downloader = pooch.HTTPDownloader(headers={"User-Agent": "regionmask"})
 
     # the file will be downloaded automatically the first time this is run.
-    return REMOTE_RESSOURCE.fetch(name, downloader=downloader)
+    return REMOTE_RESOURCE.fetch(name, downloader=downloader)
 
 
 def read_remote_shapefile(name):

--- a/regionmask/defined_regions/giorgi.py
+++ b/regionmask/defined_regions/giorgi.py
@@ -79,7 +79,7 @@ names[21] = "North Asia"
 numbers = range(1, 22)
 
 source = (
-    "Giorgi and Franciso, 2000 (http://link.springer.com/article/10.1007/PL00013733)"
+    "Giorgi and Francisco, 2000 (http://link.springer.com/article/10.1007/PL00013733)"
 )
 
 giorgi = Regions(

--- a/regionmask/tests/test_mask.py
+++ b/regionmask/tests/test_mask.py
@@ -667,7 +667,7 @@ r_US_180_cw = Regions([outline_180[::-1]])  # clockwise
 r_US_360_ccw = Regions([outline_360])  # counter clockwise
 r_US_360_cw = Regions([outline_360[::-1]])  # clockwise
 
-# define poylgon with hole
+# define polygon with hole
 poly = Polygon(outline_180, [outline_hole_180])
 r_US_hole_180_cw = Regions([poly])  # clockwise
 poly = Polygon(outline_180, [outline_hole_180[::-1]])

--- a/regionmask/tests/test_mask_cf_xarray.py
+++ b/regionmask/tests/test_mask_cf_xarray.py
@@ -76,7 +76,7 @@ def test_mask_use_cf_no_coords_found(method, coords) -> None:
 @requires_cf_xarray
 @pytest.mark.parametrize("method", MASK_METHODS)
 @pytest.mark.parametrize("drop", ([], "lon", "longitude", ["lon", "longitude"]))
-def test_mask_use_cf_ambigous_name(method, drop) -> None:
+def test_mask_use_cf_ambiguous_name(method, drop) -> None:
 
     ds = xr.merge([dummy_ds_cf, dummy_ds])
     ds = ds.drop_vars(drop)
@@ -106,7 +106,7 @@ def test_mask_use_cf_two_cf_coords(method, coords, name, use_cf) -> None:
 @requires_cf_xarray
 @pytest.mark.parametrize("method", MASK_METHODS)
 @pytest.mark.parametrize("use_cf", (True, False))
-def test_mask_use_cf_ambigous_name_resolved(method, use_cf) -> None:
+def test_mask_use_cf_ambiguous_name_resolved(method, use_cf) -> None:
 
     ds = xr.merge([dummy_ds_cf, dummy_ds])
 

--- a/regionmask/tests/test_options.py
+++ b/regionmask/tests/test_options.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 import regionmask
-from regionmask.defined_regions._ressources import _get_cache_dir
+from regionmask.defined_regions._resources import _get_cache_dir
 
 
 @pytest.mark.parametrize("invalid_option", [None, "None", "__foo__"])


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Using the [typos](https://github.com/crate-ci/typos) project. 

```
conda install typos

typos
typos -w
```

Note - it's necessary to double check the suggestions. Turns out I don't know how to write resources (it has two _s_ in the German _Ressourcen_)