### PR TITLE
remove rtd download workaround (from #570)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,6 @@ build:
     post_install:
       # install regionmask, needs to be editable
       - pip install -e .[docs]
-      - pip install git+https://github.com/pydata/xarray/
   tools:
     python: "3.12"
 

--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -8,4 +8,3 @@ dependencies:
   - pip
   - pip:
     - -e ../..[docs]
-    - git+https://github.com/pydata/xarray/ # workaround until new xarray version is out


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxx
 - [ ] Tests added
 - [ ] Passes `isort . && black . && flake8`
 - [ ] Fully documented, including `whats-new.rst`
